### PR TITLE
Entity에 Spring Validation 애노테이션 추가

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -31,6 +31,10 @@
             <artifactId>h2</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/common/src/main/java/com/food/common/common/domain/Point.java
+++ b/common/src/main/java/com/food/common/common/domain/Point.java
@@ -1,15 +1,13 @@
 package com.food.common.common.domain;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
+
 public class Point {
     private final Integer amount;
 
-    public Point(Integer amount) {
-        validate(amount);
+    public Point(@PositiveOrZero @NotNull Integer amount) {
         this.amount = amount;
-    }
-
-    private void validate(Integer amount) {
-        if (amount < 0) throw new IllegalArgumentException();
     }
 
     public Integer get() {

--- a/common/src/main/java/com/food/common/foodCategory/domain/FoodCategory.java
+++ b/common/src/main/java/com/food/common/foodCategory/domain/FoodCategory.java
@@ -3,6 +3,7 @@ package com.food.common.foodCategory.domain;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
 
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
@@ -18,7 +19,7 @@ public class FoodCategory {
 
     private String name;
 
-    public FoodCategory(final String name) {
+    public FoodCategory(@NotBlank final String name) {
         this.name = name;
     }
 

--- a/common/src/main/java/com/food/common/menu/domain/Menu.java
+++ b/common/src/main/java/com/food/common/menu/domain/Menu.java
@@ -3,10 +3,15 @@ package com.food.common.menu.domain;
 import com.food.common.store.domain.Store;
 import lombok.NoArgsConstructor;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -34,7 +39,8 @@ public class Menu {
         return id;
     }
 
-    public Menu(final Store store, final String name, final Integer amount, final ImageUrls imageUrls) {
+    public Menu(@NotNull final Store store, @NotBlank final String name,
+                @PositiveOrZero @NotNull final Integer amount, final ImageUrls imageUrls) {
         this.storeId = store.getId();
         this.name = name;
         this.amount = amount;
@@ -57,6 +63,10 @@ public class Menu {
         }
 
         public List<String> get() {
+            if (!StringUtils.hasText(imageUrls)) {
+                return Collections.EMPTY_LIST;
+            }
+
             String[] parsedUrls = imageUrls.replace("[", "")
                     .replace("]", "")
                     .split(",");

--- a/common/src/main/java/com/food/common/menu/domain/MenuOption.java
+++ b/common/src/main/java/com/food/common/menu/domain/MenuOption.java
@@ -3,6 +3,8 @@ package com.food.common.menu.domain;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
@@ -26,7 +28,9 @@ public class MenuOption {
 
     private Boolean isRequired;
 
-    public MenuOption(final Menu menu, final String title, final String selection, final Integer additionalAmount, final Boolean isRequired) {
+    public MenuOption(@NotNull final Menu menu, @NotBlank final String title,
+                      @NotBlank final String selection, final Integer additionalAmount,
+                      @NotNull final Boolean isRequired) {
         this.menuId = menu.getId();
         this.title = title;
         this.selection = selection;

--- a/common/src/main/java/com/food/common/order/domain/Order.java
+++ b/common/src/main/java/com/food/common/order/domain/Order.java
@@ -7,6 +7,7 @@ import com.food.common.user.domain.User;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
 
 import static javax.persistence.EnumType.STRING;
 import static javax.persistence.GenerationType.IDENTITY;
@@ -33,7 +34,9 @@ public class Order extends BaseTimeEntity {
 
     private Long paymentId;
 
-    public Order(final User user, final Store store, final Integer amount, final Status status, final String additionalComment, final Payment payment) {
+    public Order(@NotNull final User user, @NotNull final Store store,
+                 @NotNull final Integer amount, @NotNull final Status status,
+                 final String additionalComment, @NotNull final Payment payment) {
         this.userId = user.getId();
         this.storeId = store.getId();
         this.amount = amount;

--- a/common/src/main/java/com/food/common/order/domain/Order.java
+++ b/common/src/main/java/com/food/common/order/domain/Order.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
 
 import static javax.persistence.EnumType.STRING;
 import static javax.persistence.GenerationType.IDENTITY;
@@ -35,7 +36,7 @@ public class Order extends BaseTimeEntity {
     private Long paymentId;
 
     public Order(@NotNull final User user, @NotNull final Store store,
-                 @NotNull final Integer amount, @NotNull final Status status,
+                 @PositiveOrZero @NotNull final Integer amount, @NotNull final Status status,
                  final String additionalComment, @NotNull final Payment payment) {
         this.userId = user.getId();
         this.storeId = store.getId();

--- a/common/src/main/java/com/food/common/order/domain/OrderMenu.java
+++ b/common/src/main/java/com/food/common/order/domain/OrderMenu.java
@@ -6,6 +6,8 @@ import lombok.NoArgsConstructor;
 import org.springframework.util.CollectionUtils;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
 import java.util.List;
 
 import static javax.persistence.GenerationType.IDENTITY;
@@ -30,7 +32,10 @@ public class OrderMenu {
 
     private Short count;
 
-    public OrderMenu(final Order order, final Menu menu, final MenuOptions menuOptions, final Integer amount, final Short count) {
+    public OrderMenu(@NotNull final Order order, @NotNull final Menu menu,
+                     final MenuOptions menuOptions,
+                     @PositiveOrZero @NotNull final Integer amount,
+                     @PositiveOrZero @NotNull final Short count) {
         this.orderId = order.getId();
         this.menuId = menu.getId();
         this.menuOptions = menuOptions;

--- a/common/src/main/java/com/food/common/payment/domain/Payment.java
+++ b/common/src/main/java/com/food/common/payment/domain/Payment.java
@@ -6,6 +6,8 @@ import com.food.common.common.domain.Point;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
 
 import static javax.persistence.EnumType.STRING;
 import static javax.persistence.GenerationType.IDENTITY;
@@ -30,7 +32,9 @@ public class Payment extends BaseTimeEntity {
     @Embedded
     private PaymentPoints points;
 
-    public Payment(final Integer amount, final Method method, final Status status, final PaymentPoints points) {
+    public Payment(@PositiveOrZero @NotNull final Integer amount,
+                   @NotNull final Method method, @NotNull final Status status,
+                   @NotNull final PaymentPoints points) {
         this.amount = amount;
         this.method = method;
         this.status = status;

--- a/common/src/main/java/com/food/common/review/domain/Review.java
+++ b/common/src/main/java/com/food/common/review/domain/Review.java
@@ -6,6 +6,10 @@ import lombok.NoArgsConstructor;
 import org.springframework.util.CollectionUtils;
 
 import javax.persistence.*;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -35,7 +39,7 @@ public class Review extends BaseTimeEntity {
     @Embedded
     private ImageUrls ImageUrls;
 
-    public Review(final Order order, final Score score, final String content, final ImageUrls imageUrls) {
+    public Review(@NotNull final Order order, @NotNull final Score score, @NotBlank final String content, final ImageUrls imageUrls) {
         this.userId = order.getUserId();
         this.storeId = order.getStoreId();
         this.orderId = order.getId();
@@ -49,15 +53,8 @@ public class Review extends BaseTimeEntity {
     public static class Score {
         private Byte score;
 
-        public Score(Byte score) {
-            validate(score);
+        public Score(@NotNull @Min(0) @Max(10) Byte score) {
             this.score = score;
-        }
-
-        private void validate(Byte score) {
-            if (0 <= score && score <= 10) return;
-
-            throw new IllegalArgumentException();
         }
 
         public Byte get() {

--- a/common/src/main/java/com/food/common/store/domain/Store.java
+++ b/common/src/main/java/com/food/common/store/domain/Store.java
@@ -1,9 +1,13 @@
 package com.food.common.store.domain;
 
 import com.food.common.foodCategory.domain.FoodCategory;
+import com.food.common.store.domain.validation.ConsistentDateParameters;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
 import java.time.LocalTime;
 
 import static javax.persistence.EnumType.*;
@@ -37,9 +41,12 @@ public class Store {
 
     private Long foodCategoryId;
 
-    public Store(final String name, final String address, final Integer minOrderAmount,
-                 final LocalTime openingTime, final LocalTime closingTime, final LocalTime cookingTime,
-                 final Status status, final FoodCategory foodCategory) {
+    @ConsistentDateParameters
+    public Store(@NotBlank final String name, @NotBlank final String address,
+                 @PositiveOrZero @NotNull final Integer minOrderAmount,
+                 final LocalTime openingTime, final LocalTime closingTime,
+                 @NotNull final LocalTime cookingTime, @NotNull final Status status,
+                 @NotNull final FoodCategory foodCategory) {
         this.name = name;
         this.address = address;
         this.minOrderAmount = minOrderAmount;

--- a/common/src/main/java/com/food/common/store/domain/validation/ConsistentDateParameterValidator.java
+++ b/common/src/main/java/com/food/common/store/domain/validation/ConsistentDateParameterValidator.java
@@ -1,0 +1,29 @@
+package com.food.common.store.domain.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.constraintvalidation.SupportedValidationTarget;
+import javax.validation.constraintvalidation.ValidationTarget;
+import java.time.LocalTime;
+
+@SupportedValidationTarget(ValidationTarget.PARAMETERS)
+public class ConsistentDateParameterValidator implements ConstraintValidator<ConsistentDateParameters, Object[]> {
+
+    @Override
+    public boolean isValid(Object[] value, ConstraintValidatorContext context) {
+        Object openingTime = value[3];
+        Object closingTime = value[4];
+
+        if (openingTime == null || closingTime == null) {
+            return true;
+        }
+
+        if (!(openingTime instanceof LocalTime)
+                || !(closingTime instanceof LocalTime)) {
+            throw new IllegalArgumentException(
+                    "Illegal method signature, expected two parameters of type LocalDate.");
+        }
+
+        return ((LocalTime) openingTime).isBefore((LocalTime) closingTime);
+    }
+}

--- a/common/src/main/java/com/food/common/store/domain/validation/ConsistentDateParameters.java
+++ b/common/src/main/java/com/food/common/store/domain/validation/ConsistentDateParameters.java
@@ -1,0 +1,24 @@
+package com.food.common.store.domain.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Constraint(validatedBy = ConsistentDateParameterValidator.class)
+@Target({ METHOD, CONSTRUCTOR })
+@Retention(RUNTIME)
+@Documented
+public @interface ConsistentDateParameters {
+    String message() default
+            "closing date must be after opening date";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/common/src/main/java/com/food/common/user/domain/User.java
+++ b/common/src/main/java/com/food/common/user/domain/User.java
@@ -5,6 +5,8 @@ import com.food.common.common.domain.Point;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
@@ -25,14 +27,15 @@ public class User extends BaseTimeEntity {
 
     private Integer point;
 
-    public User(final String loginId, final String password, final String nickname, final Point point) {
+    public User(@NotBlank final String loginId, @NotBlank final String password,
+                @NotBlank final String nickname, @NotNull final Point point) {
         this.loginId = loginId;
         this.password = password;
         this.nickname = nickname;
         this.point = point.get();
     }
 
-    public Point use(final Point point) {
+    public Point use(@NotNull final Point point) {
         Point currentPoint = getPoint().subtract(point);
         this.point = currentPoint.get();
 

--- a/common/src/test/java/com/food/common/integration/SuperIntegrationTest.java
+++ b/common/src/test/java/com/food/common/integration/SuperIntegrationTest.java
@@ -1,9 +1,9 @@
-package com.food.common.repository;
+package com.food.common.integration;
 
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @Transactional
-public class CommonRepositoryTest {
+public class SuperIntegrationTest {
 }

--- a/common/src/test/java/com/food/common/integration/domain/DomainValidationIntegrationTest.java
+++ b/common/src/test/java/com/food/common/integration/domain/DomainValidationIntegrationTest.java
@@ -1,0 +1,18 @@
+package com.food.common.integration.domain;
+
+import com.food.common.integration.SuperIntegrationTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import javax.validation.Validation;
+import javax.validation.ValidatorFactory;
+import javax.validation.executable.ExecutableValidator;
+
+public class DomainValidationIntegrationTest extends SuperIntegrationTest {
+    protected static ExecutableValidator executableValidator;
+
+    @BeforeAll
+    static void setupAll() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        executableValidator = factory.getValidator().forExecutables();
+    }
+}

--- a/common/src/test/java/com/food/common/integration/domain/FoodCategoryValidationTest.java
+++ b/common/src/test/java/com/food/common/integration/domain/FoodCategoryValidationTest.java
@@ -1,0 +1,41 @@
+package com.food.common.integration.domain;
+
+import com.food.common.foodCategory.domain.FoodCategory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.validation.ConstraintViolation;
+import java.lang.reflect.Constructor;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class FoodCategoryValidationTest extends DomainValidationIntegrationTest {
+
+    private Set<ConstraintViolation<FoodCategory>> getViolationsOfUserConstructor(String name) throws NoSuchMethodException {
+        Constructor<FoodCategory> constructor = FoodCategory.class.getConstructor(String.class);
+
+        Object[] parameterValues = {name};
+
+        return executableValidator.validateConstructorParameters(constructor, parameterValues);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    @DisplayName("FoodCategory 생성자에 Name을 공백으로 넣으면 유효성 검증에 실패한다.")
+    void validationWithBlankName_thenCorrectNumberOfViolations(String name) throws NoSuchMethodException {
+        Set<ConstraintViolation<FoodCategory>> constraintViolations = getViolationsOfUserConstructor(name);
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("FoodCategory 생성자에 Name을 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullName_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<FoodCategory>> constraintViolations = getViolationsOfUserConstructor(null);
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+}

--- a/common/src/test/java/com/food/common/integration/domain/MenuOptionValidationTest.java
+++ b/common/src/test/java/com/food/common/integration/domain/MenuOptionValidationTest.java
@@ -1,0 +1,86 @@
+package com.food.common.integration.domain;
+
+import com.food.common.menu.domain.Menu;
+import com.food.common.menu.domain.MenuOption;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.validation.ConstraintViolation;
+import java.lang.reflect.Constructor;
+import java.util.Set;
+
+import static com.food.common.integration.domain.MenuValidationTest.createDummyStore;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MenuOptionValidationTest extends DomainValidationIntegrationTest {
+
+    private Set<ConstraintViolation<MenuOption>> getViolationsOfMenuOptionConstructor(Menu menu, String title, String selection, Integer additionalAmount, Boolean isRequired) throws NoSuchMethodException {
+        Constructor<MenuOption> constructor = MenuOption.class.getConstructor(Menu.class, String.class, String.class, Integer.class, Boolean.class);
+
+        Object[] parameterValues = {menu, title, selection, additionalAmount, isRequired};
+
+        return executableValidator.validateConstructorParameters(constructor, parameterValues);
+    }
+
+    @Test
+    @DisplayName("MenuOption 생성자에 Store를 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullMenu_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<MenuOption>> constraintViolations =
+                getViolationsOfMenuOptionConstructor(null, "맛 선택", "아주 매운맛", 0, true);
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("MenuOption 생성자에 Title를 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullTitle_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<MenuOption>> constraintViolations =
+                getViolationsOfMenuOptionConstructor(createDummyMenu(), null, "아주 매운맛", 0, true);
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    @DisplayName("MenuOption 생성자에 Title을 공백으로 넣으면 유효성 검증에 실패한다.")
+    void validationWithBlankTitle_thenCorrectNumberOfViolations(String title) throws NoSuchMethodException {
+        Set<ConstraintViolation<MenuOption>> constraintViolations =
+                getViolationsOfMenuOptionConstructor(createDummyMenu(), title, "아주 매운맛", 0, true);
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("MenuOption 생성자에 Selection를 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullSelection_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<MenuOption>> constraintViolations =
+                getViolationsOfMenuOptionConstructor(createDummyMenu(), "맛 선택", null, 0, true);
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    @DisplayName("MenuOption 생성자에 Selection을 공백으로 넣으면 유효성 검증에 실패한다.")
+    void validationWithBlankSelection_thenCorrectNumberOfViolations(String selection) throws NoSuchMethodException {
+        Set<ConstraintViolation<MenuOption>> constraintViolations =
+                getViolationsOfMenuOptionConstructor(createDummyMenu(), "맛 선택", selection, 0, true);
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("MenuOption 생성자에 IsRequired를 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullIsRequired_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<MenuOption>> constraintViolations =
+                getViolationsOfMenuOptionConstructor(createDummyMenu(), "맛 선택", "아주 매운맛", 0, null);
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    private Menu createDummyMenu() {
+        return new Menu(createDummyStore(), "Menu A", 12000, null);
+    }
+}

--- a/common/src/test/java/com/food/common/integration/domain/MenuValidationTest.java
+++ b/common/src/test/java/com/food/common/integration/domain/MenuValidationTest.java
@@ -1,0 +1,79 @@
+package com.food.common.integration.domain;
+
+import com.food.common.foodCategory.domain.FoodCategory;
+import com.food.common.menu.domain.Menu;
+import com.food.common.store.domain.Store;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.validation.ConstraintViolation;
+import java.lang.reflect.Constructor;
+import java.time.LocalTime;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MenuValidationTest extends DomainValidationIntegrationTest {
+    private Set<ConstraintViolation<Menu>> getViolationsOfMenuConstructor(Store store, String name, Integer amount, Menu.ImageUrls imageUrls) throws NoSuchMethodException {
+        Constructor<Menu> constructor = Menu.class.getConstructor(Store.class, String.class, Integer.class, Menu.ImageUrls.class);
+
+        Object[] parameterValues = {store, name, amount, imageUrls};
+
+        return executableValidator.validateConstructorParameters(constructor, parameterValues);
+    }
+
+    @Test
+    @DisplayName("Menu 생성자에 Store를 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullStore_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<Menu>> constraintViolations =
+                getViolationsOfMenuConstructor(null, "Menu A", 12000, null);
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    @DisplayName("Menu 생성자에 Name을 공백으로 넣으면 유효성 검증에 실패한다.")
+    void validationWithBlankName_thenCorrectNumberOfViolations(String name) throws NoSuchMethodException {
+        Set<ConstraintViolation<Menu>> constraintViolations =
+                getViolationsOfMenuConstructor(createDummyStore(), name, 12000, null);
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("Menu 생성자에 Name을 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullName_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<Menu>> constraintViolations =
+                getViolationsOfMenuConstructor(createDummyStore(), null, 12000, null);
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, -10, -1000})
+    @DisplayName("Menu 생성자에 Amount을 음수로 넣으면 유효성 검증에 실패한다.")
+    void validationWithBlankAmount_thenCorrectNumberOfViolations(Integer amount) throws NoSuchMethodException {
+        Set<ConstraintViolation<Menu>> constraintViolations =
+                getViolationsOfMenuConstructor(createDummyStore(), "Menu A", amount, null);
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("Menu 생성자에 Amount를 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullAmount_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<Menu>> constraintViolations =
+                getViolationsOfMenuConstructor(createDummyStore(), "Menu A", null, null);
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    public static Store createDummyStore() {
+        return new Store("Store Name A", "dummy address", 10000,
+                LocalTime.of(10, 00), LocalTime.of(22, 00),
+                LocalTime.of(00, 30), Store.Status.OPEN, new FoodCategory("한식"));
+    }
+}

--- a/common/src/test/java/com/food/common/integration/domain/OrderValidationTest.java
+++ b/common/src/test/java/com/food/common/integration/domain/OrderValidationTest.java
@@ -1,0 +1,98 @@
+package com.food.common.integration.domain;
+
+import com.food.common.common.domain.Point;
+import com.food.common.order.domain.Order;
+import com.food.common.payment.domain.Payment;
+import com.food.common.store.domain.Store;
+import com.food.common.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.validation.ConstraintViolation;
+import java.lang.reflect.Constructor;
+import java.util.Set;
+
+import static com.food.common.integration.domain.MenuValidationTest.createDummyStore;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class OrderValidationTest extends DomainValidationIntegrationTest {
+
+    private Set<ConstraintViolation<Order>> getViolationsOfMenuOptionConstructor(User user, Store store, Integer amount, Order.Status status, String additionalComment, Payment payment) throws NoSuchMethodException {
+        Constructor<Order> constructor = Order.class.getConstructor(User.class, Store.class, Integer.class, Order.Status.class, String.class, Payment.class);
+
+        Object[] parameterValues = {user, store, amount, status, additionalComment, payment};
+
+        return executableValidator.validateConstructorParameters(constructor, parameterValues);
+    }
+
+    @Test
+    @DisplayName("Order 생성자에 User를 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullUser_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        User dummyUser = createDummyUser();
+        Set<ConstraintViolation<Order>> constraintViolations =
+                getViolationsOfMenuOptionConstructor(null, createDummyStore(), 24000, Order.Status.REQUESTED, null, createDummyPayment(dummyUser));
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("Order 생성자에 Store를 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullStore_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        User dummyUser = createDummyUser();
+        Set<ConstraintViolation<Order>> constraintViolations =
+                getViolationsOfMenuOptionConstructor(dummyUser, null, 24000, Order.Status.REQUESTED, null, createDummyPayment(dummyUser));
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("Order 생성자에 Amount를 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullAmount_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        User dummyUser = createDummyUser();
+        Set<ConstraintViolation<Order>> constraintViolations =
+                getViolationsOfMenuOptionConstructor(dummyUser, createDummyStore(), null, Order.Status.REQUESTED, null, createDummyPayment(dummyUser));
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, -10, -1000})
+    @DisplayName("Order 생성자에 Amount을 음수로 넣으면 유효성 검증에 실패한다.")
+    void validationWithBlankAmount_thenCorrectNumberOfViolations(Integer amount) throws NoSuchMethodException {
+        User dummyUser = createDummyUser();
+        Set<ConstraintViolation<Order>> constraintViolations =
+                getViolationsOfMenuOptionConstructor(dummyUser, createDummyStore(), amount, Order.Status.REQUESTED, null, createDummyPayment(dummyUser));
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("Order 생성자에 Status를 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullStatus_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        User dummyUser = createDummyUser();
+        Set<ConstraintViolation<Order>> constraintViolations =
+                getViolationsOfMenuOptionConstructor(dummyUser, createDummyStore(), 24000, null, null, createDummyPayment(dummyUser));
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("Order 생성자에 Payment를 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullPayment_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        User dummyUser = createDummyUser();
+        Set<ConstraintViolation<Order>> constraintViolations =
+                getViolationsOfMenuOptionConstructor(dummyUser, createDummyStore(), 24000, Order.Status.REQUESTED, null, null);
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    private User createDummyUser() {
+        return new User("userA", "passwordABCD", "userA", new Point(1000));
+    }
+
+    private Payment createDummyPayment(User user) {
+        return new Payment(24000, Payment.Method.CARD, Payment.Status.PAYMENT_COMPLETED, Payment.PaymentPoints.notUse(user));
+    }
+}

--- a/common/src/test/java/com/food/common/integration/domain/PaymentValidationTest.java
+++ b/common/src/test/java/com/food/common/integration/domain/PaymentValidationTest.java
@@ -1,0 +1,79 @@
+package com.food.common.integration.domain;
+
+import com.food.common.common.domain.Point;
+import com.food.common.payment.domain.Payment;
+import com.food.common.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.validation.ConstraintViolation;
+import java.lang.reflect.Constructor;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PaymentValidationTest extends DomainValidationIntegrationTest {
+    private Set<ConstraintViolation<Payment>> getViolationsOfPaymentConstructor(Integer amount, Payment.Method method, Payment.Status status, Payment.PaymentPoints points) throws NoSuchMethodException {
+        Constructor<Payment> constructor = Payment.class.getConstructor(Integer.class, Payment.Method.class, Payment.Status.class, Payment.PaymentPoints.class);
+
+        Object[] parameterValues = {amount, method, status, points};
+
+        return executableValidator.validateConstructorParameters(constructor, parameterValues);
+    }
+
+    @Test
+    @DisplayName("Payment 생성자에 Amount를 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullAmount_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<Payment>> constraintViolations =
+                getViolationsOfPaymentConstructor(null, Payment.Method.CARD, Payment.Status.PAYMENT_COMPLETED, createDummyPaymentPoints());
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, -10, -1000})
+    @DisplayName("Payment 생성자에 Amount을 음수로 넣으면 유효성 검증에 실패한다.")
+    void validationWithBlankAmount_thenCorrectNumberOfViolations(Integer amount) throws NoSuchMethodException {
+        Set<ConstraintViolation<Payment>> constraintViolations =
+                getViolationsOfPaymentConstructor(amount, Payment.Method.CARD, Payment.Status.PAYMENT_COMPLETED, createDummyPaymentPoints());
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("Payment 생성자에 Method를 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullMethod_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<Payment>> constraintViolations =
+                getViolationsOfPaymentConstructor(24000, null, Payment.Status.PAYMENT_COMPLETED, createDummyPaymentPoints());
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("Payment 생성자에 Status를 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullStatus_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<Payment>> constraintViolations =
+                getViolationsOfPaymentConstructor(24000, Payment.Method.CARD, null, createDummyPaymentPoints());
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("Payment 생성자에 PaymentPoints를 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullPaymentPoints_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<Payment>> constraintViolations =
+                getViolationsOfPaymentConstructor(24000, Payment.Method.CARD, Payment.Status.PAYMENT_COMPLETED, null);
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    private Payment.PaymentPoints createDummyPaymentPoints() {
+        return Payment.PaymentPoints.notUse(createDummyUser());
+    }
+
+    private User createDummyUser() {
+        return new User("userA", "passwordABCD", "userA", new Point(1000));
+    }
+}

--- a/common/src/test/java/com/food/common/integration/domain/PointValidationTest.java
+++ b/common/src/test/java/com/food/common/integration/domain/PointValidationTest.java
@@ -1,0 +1,43 @@
+package com.food.common.integration.domain;
+
+import com.food.common.common.domain.Point;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.validation.ConstraintViolation;
+import java.lang.reflect.Constructor;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PointValidationTest extends DomainValidationIntegrationTest {
+
+    private Set<ConstraintViolation<Point>> getViolationsOfPointConstructor(Integer amount) throws NoSuchMethodException {
+        Constructor<Point> constructor = Point.class.getConstructor(Integer.class);
+        return executableValidator.validateConstructorParameters(constructor, new Object[]{amount});
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, -10})
+    void whenValidationWithNegativeNumberConstructorParameter_thenCorrectNumberOfViolations(int value) throws NoSuchMethodException {
+        Set<ConstraintViolation<Point>> constraintViolations = getViolationsOfPointConstructor(value);
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 10, 1000, 10000})
+    void whenValidationWithValidNumberConstructorParameter_thenCorrectNumberOfViolations(int value) throws NoSuchMethodException {
+        Set<ConstraintViolation<Point>> constraintViolations = getViolationsOfPointConstructor(value);
+
+        assertEquals(constraintViolations.size(), 0);
+    }
+
+    @Test
+    void whenValidationWithNullConstructorParameter_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<Point>> constraintViolations = getViolationsOfPointConstructor(null);
+        
+        assertEquals(constraintViolations.size(), 1);
+    }
+}

--- a/common/src/test/java/com/food/common/integration/domain/ReviewValidationTest.java
+++ b/common/src/test/java/com/food/common/integration/domain/ReviewValidationTest.java
@@ -1,0 +1,107 @@
+package com.food.common.integration.domain;
+
+import com.food.common.common.domain.Point;
+import com.food.common.order.domain.Order;
+import com.food.common.payment.domain.Payment;
+import com.food.common.review.domain.Review;
+import com.food.common.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.validation.ConstraintViolation;
+import java.lang.reflect.Constructor;
+import java.util.Set;
+
+import static com.food.common.integration.domain.MenuValidationTest.createDummyStore;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ReviewValidationTest extends DomainValidationIntegrationTest {
+    private Set<ConstraintViolation<Review>> getViolationsOfReviewConstructor(Order order, Review.Score score, String content, Review.ImageUrls imageUrls) throws NoSuchMethodException {
+        Constructor<Review> constructor = Review.class.getConstructor(Order.class, Review.Score.class, String.class, Review.ImageUrls.class);
+
+        Object[] parameterValues = {order, score, content, imageUrls};
+
+        return executableValidator.validateConstructorParameters(constructor, parameterValues);
+    }
+
+    @Test
+    @DisplayName("Review 생성자에 Order를 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullOrder_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<Review>> constraintViolations =
+                getViolationsOfReviewConstructor(null, createReviewScore(), "content test", null);
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("Review 생성자에 Score를 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullScore_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<Review>> constraintViolations =
+                getViolationsOfReviewConstructor(createDummyOrder(), null, "content test", null);
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("Review 생성자에 Content를 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullContent_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<Review>> constraintViolations =
+                getViolationsOfReviewConstructor(createDummyOrder(), createReviewScore(), null, null);
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    @DisplayName("Review 생성자에 Content를 공백으로 넣으면 유효성 검증에 실패한다.")
+    void validationWithBlankContent_thenCorrectNumberOfViolations(String content) throws NoSuchMethodException {
+        Set<ConstraintViolation<Review>> constraintViolations =
+                getViolationsOfReviewConstructor(createDummyOrder(), createReviewScore(), content, null);
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    private Set<ConstraintViolation<Review.Score>> getViolationsOfReviewScoreConstructor(Byte score) throws NoSuchMethodException {
+        Constructor<Review.Score> constructor = Review.Score.class.getConstructor(Byte.class);
+
+        Object[] parameterValues = {score};
+
+        return executableValidator.validateConstructorParameters(constructor, parameterValues);
+    }
+
+    @Test
+    @DisplayName("Review.Score 생성자에 score를 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullReviewScore_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<Review.Score>> constraintViolations = getViolationsOfReviewScoreConstructor(null);
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(bytes = {-3, -1, 11, 15})
+    @DisplayName("Review 생성자에 Content를 공백으로 넣으면 유효성 검증에 실패한다.")
+    void validationWithReviewScoreOutOfRange_thenCorrectNumberOfViolations(Byte score) throws NoSuchMethodException {
+        Set<ConstraintViolation<Review.Score>> constraintViolations = getViolationsOfReviewScoreConstructor(score);
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    private Order createDummyOrder() {
+        User dummyUser = createDummyUser();
+        return new Order(dummyUser, createDummyStore(), 24000, Order.Status.REQUESTED, null, createDummyPayment(dummyUser));
+    }
+
+    private Payment createDummyPayment(User user) {
+        return new Payment(24000, Payment.Method.CARD, Payment.Status.PAYMENT_COMPLETED, Payment.PaymentPoints.notUse(user));
+    }
+
+    private Review.Score createReviewScore() {
+        return new Review.Score((byte) 0);
+    }
+
+    private User createDummyUser() {
+        return new User("userA", "passwordABCD", "userA", new Point(1000));
+    }
+}

--- a/common/src/test/java/com/food/common/integration/domain/StoreValidationTest.java
+++ b/common/src/test/java/com/food/common/integration/domain/StoreValidationTest.java
@@ -1,0 +1,154 @@
+package com.food.common.integration.domain;
+
+import com.food.common.foodCategory.domain.FoodCategory;
+import com.food.common.store.domain.Store;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.validation.ConstraintViolation;
+import java.lang.reflect.Constructor;
+import java.time.LocalTime;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class StoreValidationTest extends DomainValidationIntegrationTest {
+
+    private Set<ConstraintViolation<Store>> getViolationsOfStoreConstructor(String name, String address, Integer minOrderAmount,
+                                                                           LocalTime openingTime, LocalTime closingTime, LocalTime cookingTime,
+                                                                           Store.Status status, FoodCategory foodCategory) throws NoSuchMethodException {
+        Constructor<Store> constructor = Store.class.getConstructor(
+                String.class, String.class, Integer.class, LocalTime.class, LocalTime.class, LocalTime.class, Store.Status.class, FoodCategory.class);
+
+        Object[] parameterValues = {name, address, minOrderAmount, openingTime, closingTime, cookingTime, status, foodCategory};
+
+        return executableValidator.validateConstructorParameters(constructor, parameterValues);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    @DisplayName("Store 생성자에 Name을 공백으로 넣으면 유효성 검증에 실패한다.")
+    void validationWithBlankName_thenCorrectNumberOfViolations(String name) throws NoSuchMethodException {
+        Set<ConstraintViolation<Store>> constraintViolations = getViolationsOfStoreConstructor(
+                name, "dummy address", 10000,
+                LocalTime.of(10, 00), LocalTime.of(22, 00),
+                LocalTime.of(00, 30), Store.Status.OPEN, new FoodCategory("한식")
+        );
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("Store 생성자에 Name을 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullName_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<Store>> constraintViolations =
+                getViolationsOfStoreConstructor(
+                        null, "dummy address", 10000,
+                        LocalTime.of(10, 00), LocalTime.of(22, 00),
+                        LocalTime.of(00, 30), Store.Status.OPEN, new FoodCategory("한식")
+                );
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    @DisplayName("Store 생성자에 Address을 공백으로 넣으면 유효성 검증에 실패한다.")
+    void validationWithBlankAddress_thenCorrectNumberOfViolations(String address) throws NoSuchMethodException {
+        Set<ConstraintViolation<Store>> constraintViolations = getViolationsOfStoreConstructor(
+                "Store Name A", address, 10000,
+                LocalTime.of(10, 00), LocalTime.of(22, 00),
+                LocalTime.of(00, 30), Store.Status.OPEN, new FoodCategory("한식")
+        );
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("Store 생성자에 Address을 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullAddress_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<Store>> constraintViolations =
+                getViolationsOfStoreConstructor(
+                        "Store Name A", null, 10000,
+                        LocalTime.of(10, 00), LocalTime.of(22, 00),
+                        LocalTime.of(00, 30), Store.Status.OPEN, new FoodCategory("한식")
+                );
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, -10, -10000})
+    @DisplayName("Store 생성자에 MinOrderAmount을 음수로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNegativeMinOrderAmount_thenCorrectNumberOfViolations(int minOrderAmount) throws NoSuchMethodException {
+        Set<ConstraintViolation<Store>> constraintViolations = getViolationsOfStoreConstructor(
+                "Store Name A", "dummy address", minOrderAmount,
+                LocalTime.of(10, 00), LocalTime.of(22, 00),
+                LocalTime.of(00, 30), Store.Status.OPEN, new FoodCategory("한식")
+        );
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("Store 생성자에 MinOrderAmount을 Null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullMinOrderAmount_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<Store>> constraintViolations = getViolationsOfStoreConstructor(
+                "Store Name A", "dummy address", null,
+                LocalTime.of(10, 00), LocalTime.of(22, 00),
+                LocalTime.of(00, 30), Store.Status.OPEN, new FoodCategory("한식")
+        );
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("Store 생성자에 OpeningTime을 ClosingTime 이후 값으로 넣으면 유효성 검증에 실패한다.")
+    void validationWithOpeningTimeValueAfterClosingTime_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<Store>> constraintViolations = getViolationsOfStoreConstructor(
+                "Store Name A", "dummy address", 10000,
+                LocalTime.of(22, 00), LocalTime.of(10, 00),
+                LocalTime.of(00, 30), Store.Status.OPEN, new FoodCategory("한식")
+        );
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("Store 생성자에 CookingTime을 Null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullCookingTime_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<Store>> constraintViolations = getViolationsOfStoreConstructor(
+                "Store Name A", "dummy address", 10000,
+                LocalTime.of(10, 00), LocalTime.of(22, 00),
+                null, Store.Status.OPEN, new FoodCategory("한식")
+        );
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("Store 생성자에 Status를 Null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullStatus_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<Store>> constraintViolations = getViolationsOfStoreConstructor(
+                "Store Name A", "dummy address", 10000,
+                LocalTime.of(10, 00), LocalTime.of(22, 00),
+                LocalTime.of(00, 30), null, new FoodCategory("한식")
+        );
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("Store 생성자에 FoodCategory를 Null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullFoodCategory_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<Store>> constraintViolations = getViolationsOfStoreConstructor(
+                "Store Name A", "dummy address", 10000,
+                LocalTime.of(10, 00), LocalTime.of(22, 00),
+                LocalTime.of(00, 30), Store.Status.OPEN, null
+        );
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+}

--- a/common/src/test/java/com/food/common/integration/domain/UserValidationTest.java
+++ b/common/src/test/java/com/food/common/integration/domain/UserValidationTest.java
@@ -1,0 +1,91 @@
+package com.food.common.integration.domain;
+
+import com.food.common.common.domain.Point;
+import com.food.common.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.validation.ConstraintViolation;
+import java.lang.reflect.Constructor;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class UserValidationTest extends DomainValidationIntegrationTest {
+
+    private Set<ConstraintViolation<User>> getViolationsOfUserConstructor(String userId, String password, String nickname, Point point) throws NoSuchMethodException {
+        Constructor<User> constructor = User.class.getConstructor(String.class, String.class, String.class, Point.class);
+
+        Object[] parameterValues = {userId, password, nickname, point};
+
+        return executableValidator.validateConstructorParameters(constructor, parameterValues);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    @DisplayName("User 생성자에 UserId를 공백으로 넣으면 유효성 검증에 실패한다.")
+    void validationWithBlankUserId_thenCorrectNumberOfViolations(String userId) throws NoSuchMethodException {
+        Set<ConstraintViolation<User>> constraintViolations =
+                getViolationsOfUserConstructor(userId, "passwordABCD", "userA", new Point(1000));
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("User 생성자에 UserId를 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullUserId_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<User>> constraintViolations =
+                getViolationsOfUserConstructor(null, "passwordABCD", "userA", new Point(1000));
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    @DisplayName("User 생성자에 Password를 공백으로 넣으면 유효성 검증에 실패한다.")
+    void validationWithBlankPassword_thenCorrectNumberOfViolations(String password) throws NoSuchMethodException {
+        Set<ConstraintViolation<User>> constraintViolations =
+                getViolationsOfUserConstructor("userA", password, "userA", new Point(1000));
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("User 생성자에 Password를 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullPassword_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<User>> constraintViolations =
+                getViolationsOfUserConstructor("userA", null, "userA", new Point(1000));
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    @DisplayName("User 생성자에 Nickname을 공백으로 넣으면 유효성 검증에 실패한다.")
+    void validationWithBlankNickname_thenCorrectNumberOfViolations(String nickname) throws NoSuchMethodException {
+        Set<ConstraintViolation<User>> constraintViolations =
+                getViolationsOfUserConstructor("userA", "passwordABCD", nickname, new Point(1000));
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("User 생성자에 Nickname을 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullNickname_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<User>> constraintViolations =
+                getViolationsOfUserConstructor("userA", "passwordABCD", null, new Point(1000));
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+
+    @Test
+    @DisplayName("User 생성자에 Point를 null로 넣으면 유효성 검증에 실패한다.")
+    void validationWithNullPoint_thenCorrectNumberOfViolations() throws NoSuchMethodException {
+        Set<ConstraintViolation<User>> constraintViolations =
+                getViolationsOfUserConstructor("userA", "passwordABCD", "userA", null);
+
+        assertEquals(constraintViolations.size(), 1);
+    }
+}

--- a/common/src/test/java/com/food/common/integration/repository/CommonRepositoryTest.java
+++ b/common/src/test/java/com/food/common/integration/repository/CommonRepositoryTest.java
@@ -1,0 +1,6 @@
+package com.food.common.integration.repository;
+
+import com.food.common.integration.SuperIntegrationTest;
+
+public class CommonRepositoryTest extends SuperIntegrationTest {
+}

--- a/common/src/test/java/com/food/common/integration/repository/MenuOptionRepositoryTest.java
+++ b/common/src/test/java/com/food/common/integration/repository/MenuOptionRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.food.common.repository;
+package com.food.common.integration.repository;
 
 import com.food.common.menu.domain.Menu;
 import com.food.common.menu.domain.MenuOption;

--- a/common/src/test/java/com/food/common/integration/repository/MenuRepositoryTest.java
+++ b/common/src/test/java/com/food/common/integration/repository/MenuRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.food.common.repository;
+package com.food.common.integration.repository;
 
 import com.food.common.menu.domain.Menu;
 import com.food.common.menu.repository.MenuRepository;

--- a/common/src/test/java/com/food/common/integration/repository/OrderRepositoryTest.java
+++ b/common/src/test/java/com/food/common/integration/repository/OrderRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.food.common.repository;
+package com.food.common.integration.repository;
 
 import com.food.common.order.domain.Order;
 import com.food.common.order.repository.OrderRepository;

--- a/common/src/test/java/com/food/common/integration/repository/PaymentRepositoryTest.java
+++ b/common/src/test/java/com/food/common/integration/repository/PaymentRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.food.common.repository;
+package com.food.common.integration.repository;
 
 import com.food.common.payment.domain.Payment;
 import com.food.common.payment.repository.PaymentRepository;

--- a/common/src/test/java/com/food/common/integration/repository/ReviewRepositoryTest.java
+++ b/common/src/test/java/com/food/common/integration/repository/ReviewRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.food.common.repository;
+package com.food.common.integration.repository;
 
 import com.food.common.order.domain.Order;
 import com.food.common.order.repository.OrderRepository;

--- a/common/src/test/java/com/food/common/integration/repository/StoreRepositoryTest.java
+++ b/common/src/test/java/com/food/common/integration/repository/StoreRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.food.common.repository;
+package com.food.common.integration.repository;
 
 import com.food.common.foodCategory.repository.FoodCategoryRepository;
 import com.food.common.store.domain.Store;

--- a/common/src/test/java/com/food/common/integration/repository/UserRepositoryTest.java
+++ b/common/src/test/java/com/food/common/integration/repository/UserRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.food.common.repository;
+package com.food.common.integration.repository;
 
 import com.food.common.common.domain.Point;
 import com.food.common.user.domain.User;

--- a/common/src/test/java/com/food/common/integration/sqlFileTest/SchemaInitializingTest.java
+++ b/common/src/test/java/com/food/common/integration/sqlFileTest/SchemaInitializingTest.java
@@ -1,4 +1,4 @@
-package com.food.common.sqlFileTest;
+package com.food.common.integration.sqlFileTest;
 
 import com.food.common.CommonApplication;
 import com.food.common.foodCategory.repository.FoodCategoryRepository;

--- a/common/src/test/java/com/food/common/unit/domain/MenuTest.java
+++ b/common/src/test/java/com/food/common/unit/domain/MenuTest.java
@@ -1,6 +1,7 @@
 package com.food.common.unit.domain;
 
 import com.food.common.menu.domain.Menu;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -17,5 +18,13 @@ public class MenuTest {
         List<String> result = imageUrls.get();
         assertThat(result)
                 .containsExactly("https://imageUrlA.jpg", "https://imageUrlB.jpg", "https://imageUrlC.jpg");
+    }
+
+    @Test
+    void shouldGetEmptyList_whenImageUrlsAreNull() {
+        Menu.ImageUrls imageUrls = new Menu.ImageUrls(null);
+
+        Assertions.assertDoesNotThrow(imageUrls::get);
+        assertThat(imageUrls.get()).isEmpty();
     }
 }

--- a/common/src/test/java/com/food/common/unit/domain/MenuTest.java
+++ b/common/src/test/java/com/food/common/unit/domain/MenuTest.java
@@ -1,4 +1,4 @@
-package com.food.common.domain;
+package com.food.common.unit.domain;
 
 import com.food.common.menu.domain.Menu;
 import org.junit.jupiter.api.Test;

--- a/common/src/test/java/com/food/common/unit/domain/ReviewTest.java
+++ b/common/src/test/java/com/food/common/unit/domain/ReviewTest.java
@@ -1,4 +1,4 @@
-package com.food.common.domain;
+package com.food.common.unit.domain;
 
 import com.food.common.review.domain.Review;
 import org.junit.jupiter.params.ParameterizedTest;


### PR DESCRIPTION
### validation 의존성 추가
* `spring-boot-starter-validation` 의존성 추가  
 (다양한 유효성 검증 애노테이션을 지원하고 있었고, 간편하게 적용할 수 있어 선택했습니다.)

### Entity 생성자 파라미터에 validation 애노테이션 추가
엔티티의 `필드`가 아닌 `생성자 파라미터`에 붙인 이유는 생성자 내에서도 `필드`에 주입하기 전에 어떠한 로직을 수행하거나 파라미터가 객체인 경우 객체 내부 메서드를 호출하기전 유효성 검증이 필요할 것 같아 `생성자 파라미터`에 붙였습니다.

### 유효성 검증 실패 처리
`예외처리 전략`을 아직 정의하지 않아 현재 PR 내용에는 포함되어 있지 않습니다. 이후 실패 응답에 대한 처리를 할 예정입니다.

### 유효성 검증 테스트 
엔티티에 추가하였던 spring validation 애노테이션 위주로 실패케이스를 검증하는 형태로 작성하였습니다.    
`mock data` 등 테스트 환경이 갖춰져있지 않아 dummy 객체 생성에 대한 코드 중복 등 보완점이 있습니다.
(테스트 환경 리팩토링 작업을 하면 PR 단위가 커질 것 같아 나누어서 올리겠습니다!)

## 그 외 보완할 점들
* 이전 PR 리뷰 코멘트를 올려주시면 해당 내용 반영 후 새로운 PR로 작성하겠습니다!  
