### PR TITLE
Entity 생성 및 db 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+common/src/main/resources/application-db.yml

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -32,6 +32,11 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <version>2.7.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>

--- a/common/src/main/java/com/food/common/address/domain/Address.java
+++ b/common/src/main/java/com/food/common/address/domain/Address.java
@@ -1,0 +1,92 @@
+package com.food.common.address.domain;
+
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import org.hibernate.validator.constraints.Length;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+import static javax.persistence.EnumType.*;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "tb_address")
+@Entity
+public class Address {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "address_id")
+    private Long id;
+
+    @Comment("우편번호")
+    @NotBlank
+    @Length(max = 30)
+    private String postCode;
+
+    @Comment("시/도명")
+    @NotBlank
+    @Length(max = 30)
+    private String sido;
+
+    @Comment("시/군/구명")
+    @NotBlank
+    @Length(max = 30)
+    private String sigungu;
+
+    @Comment("도로명/지번 유형")
+    @NotNull
+    @Enumerated(STRING)
+    private Address.Type type;
+
+    @Comment("도로명/지번 주소")
+    @NotBlank
+    @Length(max = 100)
+    private String typeAddress;
+
+    @Comment("본번")
+    @NotNull
+    private Short mainNo;
+
+    @Comment("부번")
+    @NotNull
+    private Short subNo;
+
+    @Comment("참고 주소")
+    @Length(max = 30)
+    private String referenceAddress;
+
+    public static Address create(String postCode, String sido, String sigungu,
+                                 Type type, String typeAddress, Short mainNo, Short subNo,
+                                 String referenceAddress) {
+        Address address = new Address();
+        address.postCode = postCode;
+        address.sido = sido;
+        address.sigungu = sigungu;
+        address.type = type;
+        address.typeAddress = typeAddress;
+        address.mainNo = mainNo;
+        address.subNo = subNo;
+        address.referenceAddress = referenceAddress;
+
+        return address;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public enum Type {
+        ROAD("도로명"),
+        JIBUN("지번")
+        ;
+
+        private final String description;
+
+        Type(String description) {
+            this.description = description;
+        }
+    }
+}

--- a/common/src/main/java/com/food/common/address/repository/AddressRepository.java
+++ b/common/src/main/java/com/food/common/address/repository/AddressRepository.java
@@ -1,0 +1,7 @@
+package com.food.common.address.repository;
+
+import com.food.common.address.domain.Address;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AddressRepository extends JpaRepository<Address, Long> {
+}

--- a/common/src/main/java/com/food/common/foodCategory/domain/FoodCategory.java
+++ b/common/src/main/java/com/food/common/foodCategory/domain/FoodCategory.java
@@ -1,0 +1,33 @@
+package com.food.common.foodCategory.domain;
+
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import org.hibernate.validator.constraints.Length;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "tb_food_category")
+@Entity
+public class FoodCategory {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "food_category_id")
+    private Long id;
+
+    @Comment("음식 카테고리명")
+    @NotBlank
+    @Length(max = 15)
+    private String name;
+
+    public static FoodCategory create(String name) {
+        FoodCategory foodCategory = new FoodCategory();
+        foodCategory.name = name;
+
+        return foodCategory;
+    }
+}

--- a/common/src/main/java/com/food/common/foodCategory/repository/FoodCategoryRepository.java
+++ b/common/src/main/java/com/food/common/foodCategory/repository/FoodCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.food.common.foodCategory.repository;
+
+import com.food.common.foodCategory.domain.FoodCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FoodCategoryRepository extends JpaRepository<FoodCategory, Long> {
+}

--- a/common/src/main/java/com/food/common/image/domain/Image.java
+++ b/common/src/main/java/com/food/common/image/domain/Image.java
@@ -1,0 +1,41 @@
+package com.food.common.image.domain;
+
+import com.food.common.common.domain.BaseTimeEntity;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import org.hibernate.validator.constraints.Length;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "tb_image")
+@Entity
+public class Image extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "image_id")
+    private Long id;
+
+    @Comment("저장 경로")
+    @Length(max = 200)
+    @NotBlank
+    private String path;
+
+    @Comment("파일명")
+    @Length(max = 50)
+    @NotBlank
+    private String name;
+
+    public static Image create(String path, String name) {
+        Image image = new Image();
+        image.path = path;
+        image.name = name;
+
+        return image;
+    }
+}

--- a/common/src/main/java/com/food/common/image/repository/ImageRepository.java
+++ b/common/src/main/java/com/food/common/image/repository/ImageRepository.java
@@ -1,0 +1,7 @@
+package com.food.common.image.repository;
+
+import com.food.common.image.domain.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+}

--- a/common/src/main/java/com/food/common/menu/domain/Menu.java
+++ b/common/src/main/java/com/food/common/menu/domain/Menu.java
@@ -1,0 +1,57 @@
+package com.food.common.menu.domain;
+
+import com.food.common.store.domain.Store;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import org.hibernate.validator.constraints.Length;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
+
+import java.time.LocalTime;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "tb_menu")
+@Entity
+public class Menu {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "menu_id")
+    private Long id;
+
+    @Comment("가게")
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+    @Comment("메뉴명")
+    @NotBlank
+    @Length(max = 50)
+    private String name;
+
+    @Comment("메뉴 금액")
+    @PositiveOrZero
+    @NotNull
+    private Integer amount;
+
+    @Comment("조리 시간")
+    @NotNull
+    private LocalTime cookingTime;
+
+    public static Menu create(Store store, String name, Integer amount, LocalTime cookingTime) {
+        Menu menu = new Menu();
+        menu.store = store;
+        menu.name = name;
+        menu.amount = amount;
+        menu.cookingTime = cookingTime;
+
+        return menu;
+    }
+}

--- a/common/src/main/java/com/food/common/menu/domain/Menu.java
+++ b/common/src/main/java/com/food/common/menu/domain/Menu.java
@@ -10,8 +10,6 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.PositiveOrZero;
 
-import java.time.LocalTime;
-
 import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
@@ -41,11 +39,11 @@ public class Menu {
     @NotNull
     private Integer amount;
 
-    @Comment("조리 시간")
+    @Comment("조리 시간 (분 단위)")
     @NotNull
-    private LocalTime cookingTime;
+    private Integer cookingTime;
 
-    public static Menu create(Store store, String name, Integer amount, LocalTime cookingTime) {
+    public static Menu create(Store store, String name, Integer amount, Integer cookingTime) {
         Menu menu = new Menu();
         menu.store = store;
         menu.name = name;

--- a/common/src/main/java/com/food/common/menu/domain/MenuOption.java
+++ b/common/src/main/java/com/food/common/menu/domain/MenuOption.java
@@ -1,0 +1,55 @@
+package com.food.common.menu.domain;
+
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import org.hibernate.validator.constraints.Length;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "tb_menu_option")
+@Entity
+public class MenuOption {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "menu_option_id")
+    private Long id;
+
+    @Comment("메뉴")
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "menu_id")
+    private Menu menu;
+
+    @Comment("선택옵션명")
+    @Length(max = 30)
+    @NotBlank
+    private String name;
+
+    @Comment("최소 선택 개수")
+    @Size(max = 100)
+    @NotNull
+    private Byte minSize;
+
+    @Comment("최대 선택 개수")
+    @Size(max = 100)
+    @NotNull
+    private Byte maxSize;
+
+    public static MenuOption menuOption(Menu menu, String name, Byte minSize, Byte maxSize) {
+        MenuOption menuOption = new MenuOption();
+        menuOption.menu = menu;
+        menuOption.name = name;
+        menuOption.minSize = minSize;
+        menuOption.maxSize = maxSize;
+
+        return menuOption;
+    }
+}

--- a/common/src/main/java/com/food/common/menu/domain/MenuSelection.java
+++ b/common/src/main/java/com/food/common/menu/domain/MenuSelection.java
@@ -1,0 +1,47 @@
+package com.food.common.menu.domain;
+
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import org.hibernate.validator.constraints.Length;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
+
+import static javax.persistence.FetchType.*;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "tb_menu_selection")
+@Entity
+public class MenuSelection {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "menu_selection_id")
+    private Long id;
+
+    @Comment("메뉴 선택옵션")
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "menu_option_id")
+    private MenuOption option;
+
+    @Comment("선택지")
+    @Length(max = 50)
+    @NotNull
+    private String selection;
+
+    @Comment("금액")
+    @PositiveOrZero
+    @NotNull
+    private Integer amount;
+
+    public static MenuSelection create(MenuOption option, String selection, Integer amount) {
+        MenuSelection menuSelection = new MenuSelection();
+        menuSelection.option = option;
+        menuSelection.selection = selection;
+        menuSelection.amount = amount;
+
+        return menuSelection;
+    }
+}

--- a/common/src/main/java/com/food/common/menu/repository/MenuOptionRepository.java
+++ b/common/src/main/java/com/food/common/menu/repository/MenuOptionRepository.java
@@ -1,0 +1,7 @@
+package com.food.common.menu.repository;
+
+import com.food.common.menu.domain.MenuOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuOptionRepository extends JpaRepository<MenuOption, Long> {
+}

--- a/common/src/main/java/com/food/common/menu/repository/MenuRepository.java
+++ b/common/src/main/java/com/food/common/menu/repository/MenuRepository.java
@@ -1,0 +1,7 @@
+package com.food.common.menu.repository;
+
+import com.food.common.menu.domain.Menu;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuRepository extends JpaRepository<Menu, Long> {
+}

--- a/common/src/main/java/com/food/common/menu/repository/MenuSelectionRepository.java
+++ b/common/src/main/java/com/food/common/menu/repository/MenuSelectionRepository.java
@@ -1,0 +1,7 @@
+package com.food.common.menu.repository;
+
+import com.food.common.menu.domain.MenuSelection;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuSelectionRepository extends JpaRepository<MenuSelection, Long> {
+}

--- a/common/src/main/java/com/food/common/order/domain/Order.java
+++ b/common/src/main/java/com/food/common/order/domain/Order.java
@@ -28,8 +28,8 @@ public class Order extends BaseTimeEntity {
     @Comment("구매자")
     @NotNull
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;
+    @JoinColumn(name = "customer_id")
+    private User customer;
 
     @Comment("가게")
     @NotNull
@@ -51,9 +51,9 @@ public class Order extends BaseTimeEntity {
     @Length(max = 150)
     private String comment;
 
-    public static Order create(User user, Store store, Integer amount, Status status, String comment) {
+    public static Order create(User customer, Store store, Integer amount, Status status, String comment) {
         Order order = new Order();
-        order.user = user;
+        order.customer = customer;
         order.store = store;
         order.amount = amount;
         order.status = status;

--- a/common/src/main/java/com/food/common/order/domain/Order.java
+++ b/common/src/main/java/com/food/common/order/domain/Order.java
@@ -1,0 +1,78 @@
+package com.food.common.order.domain;
+
+import com.food.common.common.domain.BaseTimeEntity;
+import com.food.common.store.domain.Store;
+import com.food.common.user.domain.User;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import org.hibernate.validator.constraints.Length;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
+
+import static javax.persistence.EnumType.STRING;
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "tb_order")
+@Entity
+public class Order extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "order_id")
+    private Long id;
+
+    @Comment("구매자")
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Comment("가게")
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+    @Comment("주문 금액")
+    @NotNull
+    @PositiveOrZero
+    private Integer amount;
+
+    @Comment("주문 상태")
+    @NotNull
+    @Enumerated(STRING)
+    private Status status;
+
+    @Comment("추가 요청 사항")
+    @Length(max = 150)
+    private String comment;
+
+    public static Order create(User user, Store store, Integer amount, Status status, String comment) {
+        Order order = new Order();
+        order.user = user;
+        order.store = store;
+        order.amount = amount;
+        order.status = status;
+        order.comment = comment;
+
+        return order;
+    }
+
+    public enum Status {
+        REQUEST("주문 요청 중"),
+        COOKING("조리 중"),
+        COMPLETED("조리 완료"),
+        CANCELED("취소")
+        ;
+
+        private final String description;
+
+        Status(String description) {
+            this.description = description;
+        }
+    }
+}

--- a/common/src/main/java/com/food/common/order/domain/OrderMenu.java
+++ b/common/src/main/java/com/food/common/order/domain/OrderMenu.java
@@ -1,0 +1,56 @@
+package com.food.common.order.domain;
+
+import com.food.common.menu.domain.Menu;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
+import javax.validation.constraints.Size;
+
+import static javax.persistence.FetchType.*;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "tb_order_menu")
+@Entity
+public class OrderMenu {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "order_menu_id")
+    private Long id;
+
+    @Comment("주문")
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "order_id")
+    private Order order;
+
+    @Comment("메뉴")
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "menu_id")
+    private Menu menu;
+
+    @Comment("금액")
+    @NotNull
+    @PositiveOrZero
+    private Integer amount;
+
+    @Comment("수량")
+    @NotNull
+    @Size(max = 100)
+    private Byte count;
+
+    public static OrderMenu create(Order order, Menu menu, Integer amount, Byte count) {
+        OrderMenu orderMenu = new OrderMenu();
+        orderMenu.order = order;
+        orderMenu.menu = menu;
+        orderMenu.amount = amount;
+        orderMenu.count = count;
+
+        return orderMenu;
+    }
+}

--- a/common/src/main/java/com/food/common/order/domain/OrderMenuSelection.java
+++ b/common/src/main/java/com/food/common/order/domain/OrderMenuSelection.java
@@ -1,0 +1,42 @@
+package com.food.common.order.domain;
+
+import com.food.common.menu.domain.MenuSelection;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+import static javax.persistence.FetchType.*;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "tb_order_menu_selection")
+@Entity
+public class OrderMenuSelection {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "order_menu_selection_id")
+    private Long id;
+
+    @Comment("주문메뉴")
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "order_menu_id")
+    private OrderMenu orderMenu;
+
+    @Comment("주문메뉴 선택옵션 선택지")
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "menu_select_id")
+    private MenuSelection menuSelection;
+
+    public static OrderMenuSelection create(OrderMenu orderMenu, MenuSelection menuSelection) {
+        OrderMenuSelection orderMenuSelection = new OrderMenuSelection();
+        orderMenuSelection.orderMenu = orderMenu;
+        orderMenuSelection.menuSelection = menuSelection;
+
+        return orderMenuSelection;
+    }
+}

--- a/common/src/main/java/com/food/common/order/repository/OrderMenuRepository.java
+++ b/common/src/main/java/com/food/common/order/repository/OrderMenuRepository.java
@@ -1,0 +1,7 @@
+package com.food.common.order.repository;
+
+import com.food.common.order.domain.OrderMenu;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderMenuRepository extends JpaRepository<OrderMenu, Long> {
+}

--- a/common/src/main/java/com/food/common/order/repository/OrderMenuSelectionRepository.java
+++ b/common/src/main/java/com/food/common/order/repository/OrderMenuSelectionRepository.java
@@ -1,0 +1,7 @@
+package com.food.common.order.repository;
+
+import com.food.common.order.domain.OrderMenuSelection;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderMenuSelectionRepository extends JpaRepository<OrderMenuSelection, Long> {
+}

--- a/common/src/main/java/com/food/common/order/repository/OrderRepository.java
+++ b/common/src/main/java/com/food/common/order/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package com.food.common.order.repository;
+
+import com.food.common.order.domain.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/common/src/main/java/com/food/common/payment/domain/Payment.java
+++ b/common/src/main/java/com/food/common/payment/domain/Payment.java
@@ -1,0 +1,47 @@
+package com.food.common.payment.domain;
+
+import com.food.common.common.domain.BaseTimeEntity;
+import com.food.common.order.domain.Order;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+import static javax.persistence.FetchType.*;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "tb_payment")
+@Entity
+public class Payment extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "payment_id")
+    private Long id;
+
+    @Comment("주문")
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "order_id")
+    private Order order;
+
+    @Comment("결제 상태")
+    @NotNull
+    private Status status;
+
+    public enum Status {
+        PAYMENT_REQUEST("결제 요청"),
+        PAYMENT_COMPLETED("결제 완료"),
+        CANCELLATION_REQUEST("결제 취소 요청"),
+        CANCELLATION_COMPLETED("결제 취소 완료")
+        ;
+
+        private final String description;
+
+        Status(String description) {
+            this.description = description;
+        }
+    }
+}

--- a/common/src/main/java/com/food/common/payment/domain/PaymentLog.java
+++ b/common/src/main/java/com/food/common/payment/domain/PaymentLog.java
@@ -1,0 +1,74 @@
+package com.food.common.payment.domain;
+
+import com.food.common.common.domain.BaseTimeEntity;
+import com.food.common.user.domain.Point;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "tb_payment_log")
+@Entity
+public class PaymentLog extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "payment_log_id")
+    private Long id;
+
+    @Comment("결제")
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "payment_id")
+    private Payment payment;
+
+    @Comment("결제 수단")
+    @NotNull
+    private Method method;
+
+    @Comment("결제 타입")
+    @NotNull
+    private Type type;
+
+    @Comment("결제 금액")
+    @PositiveOrZero
+    @NotNull
+    private Integer amount;
+
+    @Comment("사용 포인트")
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "point_id")
+    private Point point;
+
+    public enum Method {
+        CARD("카드"),
+        ACCOUNT_TRANSFER("계좌 이체"),
+        POINT("포인트")
+        ;
+
+        private final String description;
+
+        Method(String description) {
+            this.description = description;
+        }
+    }
+
+    public enum Type {
+        PAYMENT("결제"),
+        CANCELLATION("취소")
+        ;
+
+        private final String description;
+
+        Type(String description) {
+            this.description = description;
+        }
+    }
+}

--- a/common/src/main/java/com/food/common/review/domain/Review.java
+++ b/common/src/main/java/com/food/common/review/domain/Review.java
@@ -29,8 +29,8 @@ public class Review extends BaseTimeEntity {
     @Comment("작성자")
     @NotNull
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "user_id")
-    private User author;
+    @JoinColumn(name = "writer_id")
+    private User writer;
 
     @Comment("가게")
     @NotNull
@@ -54,9 +54,9 @@ public class Review extends BaseTimeEntity {
     @NotBlank
     private String content;
 
-    public static Review create(User author, Store store, Order order, Byte score, String content) {
+    public static Review create(User writer, Store store, Order order, Byte score, String content) {
         Review review = new Review();
-        review.author = author;
+        review.writer = writer;
         review.store = store;
         review.order = order;
         review.score = score;

--- a/common/src/main/java/com/food/common/review/domain/Review.java
+++ b/common/src/main/java/com/food/common/review/domain/Review.java
@@ -1,0 +1,67 @@
+package com.food.common.review.domain;
+
+import com.food.common.common.domain.BaseTimeEntity;
+import com.food.common.order.domain.Order;
+import com.food.common.store.domain.Store;
+import com.food.common.user.domain.User;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import org.hibernate.validator.constraints.Length;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "tb_review")
+@Entity
+public class Review extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "review_id")
+    private Long id;
+
+    @Comment("작성자")
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id")
+    private User author;
+
+    @Comment("가게")
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+    @Comment("주문")
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "order_id")
+    private Order order;
+
+    @Comment("평점")
+    @Size(max = 10)
+    @NotNull
+    private Byte score;
+
+    @Comment("내용")
+    @Length(max = 1000)
+    @NotBlank
+    private String content;
+
+    public static Review create(User author, Store store, Order order, Byte score, String content) {
+        Review review = new Review();
+        review.author = author;
+        review.store = store;
+        review.order = order;
+        review.score = score;
+        review.content = content;
+
+        return review;
+    }
+}

--- a/common/src/main/java/com/food/common/review/domain/ReviewImage.java
+++ b/common/src/main/java/com/food/common/review/domain/ReviewImage.java
@@ -1,0 +1,54 @@
+package com.food.common.review.domain;
+
+import com.food.common.image.domain.Image;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.io.Serializable;
+
+import static javax.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "tb_review_image")
+@Entity
+public class ReviewImage {
+
+    @Embeddable
+    @NoArgsConstructor(access = PROTECTED)
+    public static class MultiplePk implements Serializable {
+        private Long reviewId;
+
+        private Long imageId;
+
+        public MultiplePk(Long reviewId, Long imageId) {
+            this.reviewId = reviewId;
+            this.imageId = imageId;
+        }
+    }
+
+    @EmbeddedId
+    private MultiplePk pk = new MultiplePk();
+
+    @Comment("리뷰")
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "review_id")
+    private Review review;
+
+    @Comment("이미지")
+    @NotNull
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "image_id")
+    private Image image;
+
+    public static ReviewImage create(Review review, Image image) {
+        ReviewImage reviewImage = new ReviewImage();
+        reviewImage.review = review;
+        reviewImage.image = image;
+
+        return reviewImage;
+    }
+}

--- a/common/src/main/java/com/food/common/review/domain/ReviewImage.java
+++ b/common/src/main/java/com/food/common/review/domain/ReviewImage.java
@@ -19,8 +19,10 @@ public class ReviewImage {
     @Embeddable
     @NoArgsConstructor(access = PROTECTED)
     public static class MultiplePk implements Serializable {
+        @Column(name = "review_id")
         private Long reviewId;
 
+        @Column(name = "image_id")
         private Long imageId;
 
         public MultiplePk(Long reviewId, Long imageId) {
@@ -35,13 +37,13 @@ public class ReviewImage {
     @Comment("리뷰")
     @NotNull
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "review_id")
+    @JoinColumn(name = "review_id", insertable = false, updatable = false)
     private Review review;
 
     @Comment("이미지")
     @NotNull
     @OneToOne(fetch = LAZY)
-    @JoinColumn(name = "image_id")
+    @JoinColumn(name = "image_id", insertable = false, updatable = false)
     private Image image;
 
     public static ReviewImage create(Review review, Image image) {

--- a/common/src/main/java/com/food/common/review/repository/ReviewImageRepository.java
+++ b/common/src/main/java/com/food/common/review/repository/ReviewImageRepository.java
@@ -1,0 +1,7 @@
+package com.food.common.review.repository;
+
+import com.food.common.review.domain.ReviewImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
+}

--- a/common/src/main/java/com/food/common/review/repository/ReviewRepository.java
+++ b/common/src/main/java/com/food/common/review/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package com.food.common.review.repository;
+
+import com.food.common.review.domain.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+}

--- a/common/src/main/java/com/food/common/store/domain/Store.java
+++ b/common/src/main/java/com/food/common/store/domain/Store.java
@@ -1,0 +1,68 @@
+package com.food.common.store.domain;
+
+import com.food.common.user.domain.StoreOwner;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
+
+import static javax.persistence.EnumType.STRING;
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "tb_store")
+@Entity
+public class Store {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "store_id")
+    private Long id;
+
+    @Comment("상호명")
+    @NotBlank
+    private String name;
+
+    @Comment("가게 사장님")
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "store_owner_id")
+    private StoreOwner owner;
+
+    @Comment("최소 주문 금액")
+    @PositiveOrZero
+    private Integer minOrderAmount;
+
+    @Comment("운영 상태")
+    @NotNull
+    @Enumerated(STRING)
+    private OpenStatus status;
+
+    public static Store create(String name, StoreOwner owner, Integer minOrderAmount, OpenStatus status) {
+        Store store = new Store();
+        store.name = name;
+        store.owner = owner;
+        store.minOrderAmount = minOrderAmount;
+        store.status = status;
+
+        return store;
+    }
+
+    public enum OpenStatus {
+        OPEN("운영 중"),
+        CLOSED("운영 종료")
+        ;
+
+        private final String description;
+
+        OpenStatus(String description) {
+            this.description = description;
+        }
+    }
+
+}

--- a/common/src/main/java/com/food/common/store/domain/StoreAddress.java
+++ b/common/src/main/java/com/food/common/store/domain/StoreAddress.java
@@ -1,0 +1,49 @@
+package com.food.common.store.domain;
+
+import com.food.common.address.domain.Address;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import org.hibernate.validator.constraints.Length;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+import static javax.persistence.FetchType.*;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "tb_store_address")
+@Entity
+public class StoreAddress {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "store_address_id")
+    private Long id;
+
+    @Comment("가게")
+    @NotNull
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+    @Comment("가게 소재지")
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "address_id")
+    private Address address;
+
+    @Comment("직접입력 상세주소")
+    @Length(max = 150)
+    private String addressDetail;
+
+    public static StoreAddress create(Store store, Address address, String addressDetail) {
+        StoreAddress storeAddress = new StoreAddress();
+        storeAddress.store = store;
+        storeAddress.address = address;
+        storeAddress.addressDetail = addressDetail;
+
+        return storeAddress;
+    }
+}

--- a/common/src/main/java/com/food/common/store/domain/StoreFoodCategory.java
+++ b/common/src/main/java/com/food/common/store/domain/StoreFoodCategory.java
@@ -1,0 +1,56 @@
+package com.food.common.store.domain;
+
+import com.food.common.foodCategory.domain.FoodCategory;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.io.Serializable;
+
+import static javax.persistence.FetchType.*;
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "tb_store_food_category")
+@Entity
+public class StoreFoodCategory {
+
+    @Embeddable
+    @NoArgsConstructor(access = PROTECTED)
+    public static class MultiplePk implements Serializable {
+        @Column(name = "store_id")
+        private Long storeId;
+
+        @Column(name = "food_category_id")
+        private Long foodCategoryId;
+
+        public MultiplePk(Long storeId, Long foodCategoryId) {
+            this.storeId = storeId;
+            this.foodCategoryId = foodCategoryId;
+        }
+    }
+
+    @EmbeddedId
+    private MultiplePk pk = new MultiplePk();
+
+    @Comment("가게")
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "store_id", insertable = false, updatable = false)
+    private Store store;
+
+    @Comment("음식 카테고리")
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "food_category_id", insertable = false, updatable = false)
+    private FoodCategory foodCategory;
+
+    public static StoreFoodCategory create(Store store, FoodCategory foodCategory) {
+        StoreFoodCategory storeFoodCategory = new StoreFoodCategory();
+        storeFoodCategory.store = store;
+        storeFoodCategory.foodCategory = foodCategory;
+
+        return storeFoodCategory;
+    }
+}

--- a/common/src/main/java/com/food/common/store/domain/StoreImage.java
+++ b/common/src/main/java/com/food/common/store/domain/StoreImage.java
@@ -1,0 +1,54 @@
+package com.food.common.store.domain;
+
+import com.food.common.image.domain.Image;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.io.Serializable;
+
+import static javax.persistence.FetchType.*;
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "tb_store_image")
+@Entity
+public class StoreImage {
+
+    @Embeddable
+    @NoArgsConstructor(access = PROTECTED)
+    public static class MultiplePk implements Serializable {
+        private Long storeId;
+
+        private Long imageId;
+
+        public MultiplePk(Long storeId, Long imageId) {
+            this.storeId = storeId;
+            this.imageId = imageId;
+        }
+    }
+
+    @EmbeddedId
+    private MultiplePk pk = new MultiplePk();
+
+    @Comment("가게")
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+    @Comment("이미지")
+    @NotNull
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "image_id")
+    private Image image;
+
+    public static StoreImage create(Store store, Image image) {
+        StoreImage storeImage = new StoreImage();
+        storeImage.store = store;
+        storeImage.image = image;
+
+        return storeImage;
+    }
+}

--- a/common/src/main/java/com/food/common/store/domain/StoreImage.java
+++ b/common/src/main/java/com/food/common/store/domain/StoreImage.java
@@ -19,8 +19,10 @@ public class StoreImage {
     @Embeddable
     @NoArgsConstructor(access = PROTECTED)
     public static class MultiplePk implements Serializable {
+        @Column(name = "store_id")
         private Long storeId;
 
+        @Column(name = "image_id")
         private Long imageId;
 
         public MultiplePk(Long storeId, Long imageId) {
@@ -35,13 +37,13 @@ public class StoreImage {
     @Comment("가게")
     @NotNull
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "store_id")
+    @JoinColumn(name = "store_id", insertable = false, updatable = false)
     private Store store;
 
     @Comment("이미지")
     @NotNull
     @OneToOne(fetch = LAZY)
-    @JoinColumn(name = "image_id")
+    @JoinColumn(name = "image_id", insertable = false, updatable = false)
     private Image image;
 
     public static StoreImage create(Store store, Image image) {

--- a/common/src/main/java/com/food/common/store/domain/StoreOperatingTime.java
+++ b/common/src/main/java/com/food/common/store/domain/StoreOperatingTime.java
@@ -1,0 +1,69 @@
+package com.food.common.store.domain;
+
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+import java.time.LocalTime;
+
+import static javax.persistence.FetchType.*;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "tb_store_operating_time")
+@Entity
+public class StoreOperatingTime {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "store_operating_time_id")
+    private Long id;
+
+    @Comment("가게 고유번호")
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+    @Comment("영업 요일")
+    @NotNull
+    private Week week;
+
+    @Comment("영업 시작일시")
+    @NotNull
+    private LocalTime openingTime;
+
+    @Comment("영업 종료일시")
+    @NotNull
+    private LocalTime closingTime;
+
+    public static StoreOperatingTime create(Store store, Week week, LocalTime openingTime, LocalTime closingTime) {
+        StoreOperatingTime operatingTime = new StoreOperatingTime();
+        operatingTime.store = store;
+        operatingTime.week = week;
+        operatingTime.openingTime = openingTime;
+        operatingTime.closingTime = closingTime;
+
+        return operatingTime;
+    }
+
+    public enum Week {
+        MON("월요일"),
+        TUE("화요일"),
+        WED("수요일"),
+        THU("목요일"),
+        FRI("금요일"),
+        SAT("토요일"),
+        SUN("일요일")
+        ;
+
+        private final String description;
+
+        Week(String description) {
+            this.description = description;
+        }
+    }
+}

--- a/common/src/main/java/com/food/common/store/repository/StoreAddressRepository.java
+++ b/common/src/main/java/com/food/common/store/repository/StoreAddressRepository.java
@@ -1,0 +1,7 @@
+package com.food.common.store.repository;
+
+import com.food.common.store.domain.StoreAddress;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreAddressRepository extends JpaRepository<StoreAddress, Long> {
+}

--- a/common/src/main/java/com/food/common/store/repository/StoreImageRepository.java
+++ b/common/src/main/java/com/food/common/store/repository/StoreImageRepository.java
@@ -1,0 +1,7 @@
+package com.food.common.store.repository;
+
+import com.food.common.store.domain.StoreImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreImageRepository extends JpaRepository<StoreImage, StoreImage.MultiplePk> {
+}

--- a/common/src/main/java/com/food/common/store/repository/StoreOperatingTimeRepository.java
+++ b/common/src/main/java/com/food/common/store/repository/StoreOperatingTimeRepository.java
@@ -1,0 +1,7 @@
+package com.food.common.store.repository;
+
+import com.food.common.store.domain.StoreOperatingTime;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreOperatingTimeRepository extends JpaRepository<StoreOperatingTime, Long> {
+}

--- a/common/src/main/java/com/food/common/store/repository/StoreRepository.java
+++ b/common/src/main/java/com/food/common/store/repository/StoreRepository.java
@@ -1,0 +1,7 @@
+package com.food.common.store.repository;
+
+import com.food.common.store.domain.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+}

--- a/common/src/main/java/com/food/common/user/domain/AppAccount.java
+++ b/common/src/main/java/com/food/common/user/domain/AppAccount.java
@@ -21,17 +21,17 @@ public class AppAccount extends BaseTimeEntity {
     @Column(name = "app_account_id")
     private Long id;
 
+    @Comment("로그인 아이디")
     @NotBlank
     @Email
-    @Comment("로그인 아이디")
     private String loginId;
 
-    @NotBlank
     @Comment("비밀번호")
+    @NotBlank
     private String password;
 
-    @NotNull
     @Comment("유저")
+    @NotNull
     @OneToOne
     @JoinColumn(name = "user_id")
     private User user;

--- a/common/src/main/java/com/food/common/user/domain/AppAccount.java
+++ b/common/src/main/java/com/food/common/user/domain/AppAccount.java
@@ -3,6 +3,7 @@ package com.food.common.user.domain;
 import com.food.common.common.domain.BaseTimeEntity;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
+import org.hibernate.validator.constraints.Length;
 
 import javax.persistence.*;
 import javax.validation.constraints.Email;
@@ -24,10 +25,12 @@ public class AppAccount extends BaseTimeEntity {
     @Comment("로그인 아이디")
     @NotBlank
     @Email
+    @Length(max = 50)
     private String loginId;
 
     @Comment("비밀번호")
     @NotBlank
+    @Length(max = 100)
     private String password;
 
     @Comment("유저")

--- a/common/src/main/java/com/food/common/user/domain/AppAccount.java
+++ b/common/src/main/java/com/food/common/user/domain/AppAccount.java
@@ -1,0 +1,51 @@
+package com.food.common.user.domain;
+
+import com.food.common.common.domain.BaseTimeEntity;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import javax.persistence.*;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "tb_app_account")
+@Entity
+public class AppAccount extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "app_account_id")
+    private Long id;
+
+    @NotBlank
+    @Email
+    @Comment("로그인 아이디")
+    private String loginId;
+
+    @NotBlank
+    @Comment("비밀번호")
+    private String password;
+
+    @NotNull
+    @Comment("유저")
+    @OneToOne
+    @JoinColumn(name = "USER_ID")
+    private User user;
+
+    public static AppAccount create(String loginId, String password, User user) {
+        AppAccount appAccount = new AppAccount();
+        appAccount.loginId = loginId;
+        appAccount.password = password;
+        appAccount.user = user;
+
+        return appAccount;
+    }
+
+    public Long getId() {
+        return id;
+    }
+}

--- a/common/src/main/java/com/food/common/user/domain/Point.java
+++ b/common/src/main/java/com/food/common/user/domain/Point.java
@@ -1,0 +1,61 @@
+package com.food.common.user.domain;
+
+import com.food.common.payment.domain.Payment;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
+
+import static javax.persistence.FetchType.*;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "tb_point")
+@Entity
+public class Point {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "point_id")
+    private Long id;
+
+    @Comment("유저")
+    @NotNull
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Comment("적립/사용 타입")
+    @NotNull
+    private Type type;
+
+    @Comment("포인트 금액")
+    @PositiveOrZero
+    @NotNull
+    private Integer changedAmount;
+
+    @Comment("잔여 포인트 금액")
+    @PositiveOrZero
+    @NotNull
+    private Integer currentAmount;
+
+    @Comment("결제정보")
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "payment_id")
+    private Payment payment;
+
+    public enum Type {
+        COLLECT("적립"),
+        USE("사용")
+        ;
+
+        private final String description;
+
+        Type(String description) {
+            this.description = description;
+        }
+    }
+}

--- a/common/src/main/java/com/food/common/user/domain/SocialAccount.java
+++ b/common/src/main/java/com/food/common/user/domain/SocialAccount.java
@@ -20,12 +20,12 @@ public class SocialAccount extends BaseTimeEntity {
     @Column(name = "app_account_id")
     private Long id;
 
-    @NotBlank
     @Comment("로그인 아이디")
+    @NotBlank
     private String loginId;
 
-    @NotNull
     @Comment("유저")
+    @NotNull
     @OneToOne
     @JoinColumn(name = "user_id")
     private User user;

--- a/common/src/main/java/com/food/common/user/domain/SocialAccount.java
+++ b/common/src/main/java/com/food/common/user/domain/SocialAccount.java
@@ -5,7 +5,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 
 import javax.persistence.*;
-import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
@@ -13,22 +12,17 @@ import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 @NoArgsConstructor(access = PROTECTED)
-@Table(name = "tb_app_account")
+@Table(name = "tb_social_account")
 @Entity
-public class AppAccount extends BaseTimeEntity {
+public class SocialAccount extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = IDENTITY)
     @Column(name = "app_account_id")
     private Long id;
 
     @NotBlank
-    @Email
     @Comment("로그인 아이디")
     private String loginId;
-
-    @NotBlank
-    @Comment("비밀번호")
-    private String password;
 
     @NotNull
     @Comment("유저")
@@ -36,13 +30,12 @@ public class AppAccount extends BaseTimeEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    public static AppAccount create(String loginId, String password, User user) {
-        AppAccount appAccount = new AppAccount();
-        appAccount.loginId = loginId;
-        appAccount.password = password;
-        appAccount.user = user;
+    public static SocialAccount create(String loginId, User user) {
+        SocialAccount socialAccount = new SocialAccount();
+        socialAccount.loginId = loginId;
+        socialAccount.user = user;
 
-        return appAccount;
+        return socialAccount;
     }
 
     public Long getId() {

--- a/common/src/main/java/com/food/common/user/domain/StoreOwner.java
+++ b/common/src/main/java/com/food/common/user/domain/StoreOwner.java
@@ -3,28 +3,21 @@ package com.food.common.user.domain;
 import com.food.common.common.domain.BaseTimeEntity;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
-import org.hibernate.validator.constraints.Length;
 
 import javax.persistence.*;
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 @NoArgsConstructor(access = PROTECTED)
-@Table(name = "tb_social_account")
+@Table(name = "tb_store_owner")
 @Entity
-public class SocialAccount extends BaseTimeEntity {
+public class StoreOwner extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = IDENTITY)
-    @Column(name = "app_account_id")
+    @Column(name = "store_owner_id")
     private Long id;
-
-    @Comment("로그인 아이디")
-    @NotBlank
-    @Length(max = 50)
-    private String loginId;
 
     @Comment("유저")
     @NotNull
@@ -32,12 +25,11 @@ public class SocialAccount extends BaseTimeEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    public static SocialAccount create(String loginId, User user) {
-        SocialAccount socialAccount = new SocialAccount();
-        socialAccount.loginId = loginId;
-        socialAccount.user = user;
+    public static StoreOwner create(User user) {
+        StoreOwner storeOwner = new StoreOwner();
+        storeOwner.user = user;
 
-        return socialAccount;
+        return storeOwner;
     }
 
     public Long getId() {

--- a/common/src/main/java/com/food/common/user/domain/User.java
+++ b/common/src/main/java/com/food/common/user/domain/User.java
@@ -17,8 +17,8 @@ public class User {
     @Column(name = "user_id")
     private Long id;
 
-    @NotBlank
     @Comment("닉네임")
+    @NotBlank
     private String nickname;
 
     public static User create(String nickname) {

--- a/common/src/main/java/com/food/common/user/domain/User.java
+++ b/common/src/main/java/com/food/common/user/domain/User.java
@@ -1,0 +1,34 @@
+package com.food.common.user.domain;
+
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "tb_user")
+@Entity
+public class User {
+    @Id @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @NotBlank
+    @Comment("닉네임")
+    private String nickname;
+
+    public static User create(String nickname) {
+        User user = new User();
+        user.nickname = nickname;
+
+        return user;
+    }
+
+    public Long getId() {
+        return id;
+    }
+}

--- a/common/src/main/java/com/food/common/user/domain/UserAddress.java
+++ b/common/src/main/java/com/food/common/user/domain/UserAddress.java
@@ -1,0 +1,57 @@
+package com.food.common.user.domain;
+
+import com.food.common.address.domain.Address;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import org.hibernate.validator.constraints.Length;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+import static javax.persistence.FetchType.*;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "tb_user_address")
+@Entity
+public class UserAddress {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "user_address_id")
+    private Long id;
+
+    @Comment("유저")
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Comment("주소별칭")
+    @Length(max = 30)
+    private String name;
+
+    @Comment("주소")
+    @NotNull
+    @ManyToOne
+    @JoinColumn(name = "address_id")
+    private Address address;
+
+    @Comment("직접 입력 상세 주소")
+    @Length(max = 150)
+    private String addressDetail;
+
+    public static UserAddress create(User user, String name, Address address, String addressDetail) {
+        UserAddress userAddress = new UserAddress();
+        userAddress.user = user;
+        userAddress.name = name;
+        userAddress.address = address;
+        userAddress.addressDetail = addressDetail;
+
+        return userAddress;
+    }
+
+    public Long getId() {
+        return id;
+    }
+}

--- a/common/src/main/java/com/food/common/user/repository/AppAccountRepository.java
+++ b/common/src/main/java/com/food/common/user/repository/AppAccountRepository.java
@@ -1,0 +1,7 @@
+package com.food.common.user.repository;
+
+import com.food.common.user.domain.AppAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AppAccountRepository extends JpaRepository<AppAccount, Long> {
+}

--- a/common/src/main/java/com/food/common/user/repository/SocialAccountRepository.java
+++ b/common/src/main/java/com/food/common/user/repository/SocialAccountRepository.java
@@ -1,0 +1,8 @@
+package com.food.common.user.repository;
+
+
+import com.food.common.user.domain.SocialAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SocialAccountRepository extends JpaRepository<SocialAccount, Long> {
+}

--- a/common/src/main/java/com/food/common/user/repository/StoreOwnerRepository.java
+++ b/common/src/main/java/com/food/common/user/repository/StoreOwnerRepository.java
@@ -1,0 +1,7 @@
+package com.food.common.user.repository;
+
+import com.food.common.user.domain.StoreOwner;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreOwnerRepository extends JpaRepository<StoreOwner, Long> {
+}

--- a/common/src/main/java/com/food/common/user/repository/UserAddressRepository.java
+++ b/common/src/main/java/com/food/common/user/repository/UserAddressRepository.java
@@ -1,0 +1,7 @@
+package com.food.common.user.repository;
+
+import com.food.common.user.domain.UserAddress;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserAddressRepository extends JpaRepository<UserAddress, Long> {
+}

--- a/common/src/main/java/com/food/common/user/repository/UserRepository.java
+++ b/common/src/main/java/com/food/common/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.food.common.user.repository;
+
+import com.food.common.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/common/src/main/resources/application.yml
+++ b/common/src/main/resources/application.yml
@@ -1,12 +1,3 @@
 spring:
-  datasource:
-    url: jdbc:h2:mem:/food_service
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver
-  jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
-    defer-datasource-initialization: true
-    show-sql: true
-    hibernate:
-      ddl-auto: none
+  profiles:
+    include: db

--- a/common/src/test/java/com/food/common/integration/SuperIntegrationTest.java
+++ b/common/src/test/java/com/food/common/integration/SuperIntegrationTest.java
@@ -1,7 +1,22 @@
 package com.food.common.integration;
 
+import com.food.common.config.JpaAuditConfig;
+import com.food.common.integration.mockFactory.UserFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
 
-@DataJpaTest
+@Import({
+        UserFactory.class
+})
+@DataJpaTest(includeFilters = @ComponentScan.Filter(
+        type = FilterType.ASSIGNABLE_TYPE,
+        classes = JpaAuditConfig.class
+))
 public class SuperIntegrationTest {
+
+    @Autowired
+    protected UserFactory userFactory;
 }

--- a/common/src/test/java/com/food/common/integration/SuperIntegrationTest.java
+++ b/common/src/test/java/com/food/common/integration/SuperIntegrationTest.java
@@ -1,9 +1,7 @@
 package com.food.common.integration;
 
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-@SpringBootTest
-@Transactional
+@DataJpaTest
 public class SuperIntegrationTest {
 }

--- a/common/src/test/java/com/food/common/integration/address/AddressRepositoryTests.java
+++ b/common/src/test/java/com/food/common/integration/address/AddressRepositoryTests.java
@@ -15,13 +15,14 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 public class AddressRepositoryTests extends SuperIntegrationTest {
 
     @Autowired
     private AddressRepository addressRepository;
 
-    @DisplayName("")
+    @DisplayName("우편번호는 비어있거나 글자수가 30자를 초과하면 유효성검증에 실패한다")
     @Test
     void postCodeShouldNotBeEmptyOrGreaterLettersThan30() {
         List<Executable> executables = new ArrayList<>();
@@ -49,7 +50,7 @@ public class AddressRepositoryTests extends SuperIntegrationTest {
                 .build();
     }
 
-    @DisplayName("")
+    @DisplayName("시도는 비어있거나 글자수가 30자를 초과하면 유효성 검증에 실패한다")
     @Test
     void sidoShouldNotBeEmptyOrGreaterLettersThan30() {
         List<Executable> executables = new ArrayList<>();
@@ -81,7 +82,7 @@ public class AddressRepositoryTests extends SuperIntegrationTest {
                 .build();
     }
 
-    @DisplayName("")
+    @DisplayName("시군구는 비어있거나 글자수가 30자를 초과하면 유효성 검증에 실패한다")
     @Test
     void sigunguShouldNotBeEmptyOrGreaterLettersThan30() {
         List<Executable> executables = new ArrayList<>();
@@ -113,7 +114,7 @@ public class AddressRepositoryTests extends SuperIntegrationTest {
                 .build();
     }
 
-    @DisplayName("")
+    @DisplayName("주소유형은 null이면 유효성 검증에 실패한다")
     @Test
     void typeShouldNotBeNull() {
         List<Executable> executables = new ArrayList<>();
@@ -140,7 +141,7 @@ public class AddressRepositoryTests extends SuperIntegrationTest {
                 .build();
     }
 
-    @DisplayName("")
+    @DisplayName("지번/도로명 주소는 비어있거나 글자수가 100자를 초과하면 유효성 검증에 실패한다")
     @Test
     void typeAddressShouldNotBeEmptyOrGreaterLettersThan100() {
         List<Executable> executables = new ArrayList<>();
@@ -172,7 +173,7 @@ public class AddressRepositoryTests extends SuperIntegrationTest {
                 .build();
     }
 
-    @DisplayName("")
+    @DisplayName("주소 본번과 부번은 null값이면 유효성검증에 실패한다")
     @Test
     void mainNoAndSubNoShouldNotBeNull() {
         List<Executable> executables = new ArrayList<>();
@@ -203,9 +204,7 @@ public class AddressRepositoryTests extends SuperIntegrationTest {
     }
 
     public Executable createAssertDoesNotThrowAnyExceptionExecutable(Address address, String failMessage, Object... args) {
-        return () -> assertThatThrownBy(() ->
-                addressRepository.save(address), failMessage, args)
-                .doesNotThrowAnyException();
+        return () -> assertDoesNotThrow(() -> addressRepository.save(address), String.format(failMessage, args));
     }
 
 

--- a/common/src/test/java/com/food/common/integration/address/AddressRepositoryTests.java
+++ b/common/src/test/java/com/food/common/integration/address/AddressRepositoryTests.java
@@ -1,0 +1,224 @@
+package com.food.common.integration.address;
+
+import com.food.common.address.domain.Address;
+import com.food.common.address.repository.AddressRepository;
+import com.food.common.integration.SuperIntegrationTest;
+import com.food.common.mock.MockAddress;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.validation.ConstraintViolationException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class AddressRepositoryTests extends SuperIntegrationTest {
+
+    @Autowired
+    private AddressRepository addressRepository;
+
+    @DisplayName("")
+    @Test
+    void postCodeShouldNotBeEmptyOrGreaterLettersThan30() {
+        List<Executable> executables = new ArrayList<>();
+
+        for (String blankValue : blankValues()) {
+            String failMessage = String.format("Address의 PostCode가 비어있으면 유효성 검증에 실패해야한다. value: %s", blankValue);
+            Executable executable = createAssertThrownByExecutable(createAddressWithPostCode(blankValue), failMessage);
+
+            executables.add(executable);
+        }
+
+        for (String longValue : longValues(31)) {
+            String failMessage = String.format("Address의 PostCode가 30자 이상일 경우 유효성 검증에 실패해야한다. value: %s, length: %d", longValue, longValue.length());
+            Executable executable = createAssertThrownByExecutable(createAddressWithPostCode(longValue), failMessage);
+
+            executables.add(executable);
+        }
+
+        assertAll(executables);
+    }
+
+    private Address createAddressWithPostCode(String postCode) {
+        return MockAddress.builder()
+                .postCode(postCode)
+                .build();
+    }
+
+    @DisplayName("")
+    @Test
+    void sidoShouldNotBeEmptyOrGreaterLettersThan30() {
+        List<Executable> executables = new ArrayList<>();
+
+        for (String blankValue : blankValues()) {
+            Executable executable = createAssertThrownByExecutable(
+                    createAddressWithSido(blankValue),
+                    "Address의 Sido가 비어있으면 유효성 검증에 실패해야한다. value: %s",
+                    blankValue);
+
+            executables.add(executable);
+        }
+
+        for (String longValue : longValues(31)) {
+            Executable executable = createAssertThrownByExecutable(
+                    createAddressWithSido(longValue),
+                    "Address의 Sido가 30자 이상일 경우 유효성 검증에 실패해야한다. value: %s, length: %d",
+                    longValue, longValue.length());
+
+            executables.add(executable);
+        }
+
+        assertAll(executables);
+    }
+
+    private Address createAddressWithSido(String sido) {
+        return MockAddress.builder()
+                .sido(sido)
+                .build();
+    }
+
+    @DisplayName("")
+    @Test
+    void sigunguShouldNotBeEmptyOrGreaterLettersThan30() {
+        List<Executable> executables = new ArrayList<>();
+
+        for (String blankValue : blankValues()) {
+            Executable executable = createAssertThrownByExecutable(
+                    createAddressWithSigungu(blankValue),
+                    "Address의 sigungu가 비어있으면 유효성 검증에 실패해야한다. value: %s",
+                    blankValue);
+
+            executables.add(executable);
+        }
+
+        for (String longValue : longValues(31)) {
+            Executable executable = createAssertThrownByExecutable(
+                    createAddressWithSigungu(longValue),
+                    "Address의 sigungu가 30자 이상일 경우 유효성 검증에 실패해야한다. value: %s, length: %d",
+                    longValue, longValue.length());
+
+            executables.add(executable);
+        }
+
+        assertAll(executables);
+    }
+
+    private Address createAddressWithSigungu(String sigungu) {
+        return MockAddress.builder()
+                .sigungu(sigungu)
+                .build();
+    }
+
+    @DisplayName("")
+    @Test
+    void typeShouldNotBeNull() {
+        List<Executable> executables = new ArrayList<>();
+
+        Executable executable = createAssertThrownByExecutable(
+                createAddressWithType(null),
+                "Address의 Type가 null일 경우 유효성 검증에 실패해야한다.");
+
+        executables.add(executable);
+
+        for (Address.Type addressType : Address.Type.values()) {
+            Executable executable1 = createAssertDoesNotThrowAnyExceptionExecutable(createAddressWithType(addressType),
+                    "Address의 Type은 Enum타입 모두 허용해야한다. value: %s", addressType);
+
+            executables.add(executable1);
+        }
+
+        assertAll(executables);
+    }
+
+    private Address createAddressWithType(Address.Type type) {
+        return MockAddress.builder()
+                .type(type)
+                .build();
+    }
+
+    @DisplayName("")
+    @Test
+    void typeAddressShouldNotBeEmptyOrGreaterLettersThan100() {
+        List<Executable> executables = new ArrayList<>();
+
+        for (String blankValue : blankValues()) {
+            Executable executable = createAssertThrownByExecutable(
+                    createAddressWithTypeAddress(blankValue),
+                    "Address의 typeAddress가 비어있으면 유효성 검증에 실패해야한다. value: %s",
+                    blankValue);
+
+            executables.add(executable);
+        }
+
+        for (String longValue : longValues(101)) {
+            Executable executable = createAssertThrownByExecutable(
+                    createAddressWithTypeAddress(longValue),
+                    "Address의 typeAddress가 100자 이상일 경우 유효성 검증에 실패해야한다. value: %s, length: %d",
+                    longValue, longValue.length());
+
+            executables.add(executable);
+        }
+
+        assertAll(executables);
+    }
+
+    private Address createAddressWithTypeAddress(String typeAddress) {
+        return MockAddress.builder()
+                .typeAddress(typeAddress)
+                .build();
+    }
+
+    @DisplayName("")
+    @Test
+    void mainNoAndSubNoShouldNotBeNull() {
+        List<Executable> executables = new ArrayList<>();
+
+        Address addressWithNullMainNo = MockAddress.builder()
+                .mainNo(null)
+                .build();
+        Executable mainExecutable = createAssertThrownByExecutable(addressWithNullMainNo,
+                "Address의 mainNo가 null일 경우 유효성 검증에 실패해야한다.");
+
+        executables.add(mainExecutable);
+
+        Address addressWithNullSubNo = MockAddress.builder()
+                .subNo(null)
+                .build();
+        Executable subExecutable = createAssertThrownByExecutable(addressWithNullSubNo,
+                "Address의 subNo가 null일 경우 유효성 검증에 실패해야한다.");
+
+        executables.add(subExecutable);
+
+        assertAll(executables);
+    }
+
+    public Executable createAssertThrownByExecutable(Address address, String failMessage, Object... args) {
+        return () -> assertThatThrownBy(() ->
+                        addressRepository.save(address), failMessage, args)
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    public Executable createAssertDoesNotThrowAnyExceptionExecutable(Address address, String failMessage, Object... args) {
+        return () -> assertThatThrownBy(() ->
+                addressRepository.save(address), failMessage, args)
+                .doesNotThrowAnyException();
+    }
+
+
+    private List<String> blankValues() {
+        List<String> result = new ArrayList<>();
+        result.add("");
+        result.add(" ");
+        result.add("   ");
+        result.add(null);
+        return result;
+    }
+
+    private List<String> longValues(int length) {
+        return List.of("a".repeat(length), "가".repeat(length));
+    }
+}

--- a/common/src/test/java/com/food/common/integration/mockFactory/UserFactory.java
+++ b/common/src/test/java/com/food/common/integration/mockFactory/UserFactory.java
@@ -1,0 +1,28 @@
+package com.food.common.integration.mockFactory;
+
+import com.food.common.mock.MockUser;
+import com.food.common.user.domain.User;
+import com.food.common.user.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestComponent;
+
+@TestComponent
+public class UserFactory {
+    @Autowired
+    private UserRepository userRepository;
+
+    public User user() {
+        User user = MockUser.builder()
+                .build();
+
+        return userRepository.save(user);
+    }
+
+    public User user(String nickname) {
+        User user = MockUser.builder()
+                .nickname(nickname)
+                .build();
+
+        return userRepository.save(user);
+    }
+}

--- a/common/src/test/java/com/food/common/integration/user/AppAccountRepositoryTests.java
+++ b/common/src/test/java/com/food/common/integration/user/AppAccountRepositoryTests.java
@@ -1,0 +1,27 @@
+package com.food.common.integration.user;
+
+import com.food.common.integration.SuperIntegrationTest;
+import com.food.common.user.domain.AppAccount;
+import com.food.common.user.domain.User;
+import com.food.common.user.repository.AppAccountRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AppAccountRepositoryTests extends SuperIntegrationTest {
+    @Autowired
+    private AppAccountRepository appAccountRepository;
+
+    @DisplayName("AppAccount가 정상적으로 저장된다")
+    @Test
+    void shouldSaveAppAccount() {
+        User user = userFactory.user();
+        AppAccount account = AppAccount.create("testUser@email.com", "abcd1234!@#$", user);
+
+        AppAccount savedAccount = appAccountRepository.save(account);
+        assertThat(savedAccount).isNotNull();
+        assertThat(savedAccount.getId()).isNotNull();
+    }
+}

--- a/common/src/test/java/com/food/common/integration/user/AppAccountRepositoryTests.java
+++ b/common/src/test/java/com/food/common/integration/user/AppAccountRepositoryTests.java
@@ -4,24 +4,72 @@ import com.food.common.integration.SuperIntegrationTest;
 import com.food.common.user.domain.AppAccount;
 import com.food.common.user.domain.User;
 import com.food.common.user.repository.AppAccountRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.validation.ConstraintViolationException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class AppAccountRepositoryTests extends SuperIntegrationTest {
+
     @Autowired
     private AppAccountRepository appAccountRepository;
+
+    private User mockUser;
+
+    @BeforeEach
+    void setup() {
+        mockUser = userFactory.user();
+    }
 
     @DisplayName("AppAccount가 정상적으로 저장된다")
     @Test
     void shouldSaveAppAccount() {
-        User user = userFactory.user();
-        AppAccount account = AppAccount.create("testUser@email.com", "abcd1234!@#$", user);
+        AppAccount account = AppAccount.create("testUser@email.com", "abcd1234!@#$", mockUser);
 
         AppAccount savedAccount = appAccountRepository.save(account);
         assertThat(savedAccount).isNotNull();
         assertThat(savedAccount.getId()).isNotNull();
+    }
+
+    @DisplayName("AppAccount 유효성 실패케이이스를 검증한다")
+    @Test
+    void shouldBeFailedValidation() {
+        assertAll(
+                () -> assertAll(Stream.of("", " ", "   ")
+                        .map(blankValue -> (Executable) () -> {
+                                AppAccount account = AppAccount.create("testUser@email.com", blankValue, mockUser);
+
+                                assertThatThrownBy(() -> appAccountRepository.save(account),
+                                        "AppAccount의 Password가 공백일 경우 유효성 검증에 실패한다. value="+blankValue)
+                                        .isInstanceOf(ConstraintViolationException.class);
+                            })
+                        .collect(Collectors.toList())),
+
+                () -> assertAll(Stream.of("", " ", "   ", "testId", "testId1234", "Test1234@.com")
+                        .map(value -> (Executable) () -> {
+                            AppAccount account = AppAccount.create(value, "abcd1234!@#$", mockUser);
+
+                            assertThatThrownBy(() -> appAccountRepository.save(account),
+                                    "AppAccount의 LoginId가 공백이거나 이메일 형식이 아닐 경우 유효성 검증에 실패해야한다. value="+value)
+                                    .isInstanceOf(ConstraintViolationException.class);
+                        }).collect(Collectors.toList())),
+
+                () -> {
+                    AppAccount account = AppAccount.create("testUser@email.com", "abcd1234!@#$", null);
+
+                    assertThatThrownBy(() -> appAccountRepository.save(account),
+                            "AppAccount의 User가 null일 경우 유효성 검증에 실패해야한다")
+                            .isInstanceOf(ConstraintViolationException.class);
+                }
+        );
     }
 }

--- a/common/src/test/java/com/food/common/integration/user/RepositoryTests.java
+++ b/common/src/test/java/com/food/common/integration/user/RepositoryTests.java
@@ -1,0 +1,40 @@
+package com.food.common.integration.user;
+
+import com.food.common.integration.SuperIntegrationTest;
+import com.food.common.user.domain.User;
+import com.food.common.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.validation.ConstraintViolationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class RepositoryTests extends SuperIntegrationTest {
+    @Autowired
+    private UserRepository userRepository;
+
+    @DisplayName("User가 정상적으로 저장된다")
+    @Test
+    void shouldSaveUser() {
+        User userA = User.create("userA");
+        User savedUser = userRepository.save(userA);
+
+        assertThat(savedUser).isNotNull();
+        assertThat(savedUser.getId()).isNotNull();
+    }
+
+    @DisplayName("Nickname이 공백인 User를 저장할 경우 유효성 검증에 실패한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "   "})
+    void shouldThrowException_whenSaveUserWithBlankNickname(String nickname) {
+        User userA = User.create(nickname);
+
+        assertThatThrownBy(() -> userRepository.save(userA))
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+}

--- a/common/src/test/java/com/food/common/integration/user/SocialAccountRepositoryTests.java
+++ b/common/src/test/java/com/food/common/integration/user/SocialAccountRepositoryTests.java
@@ -1,0 +1,65 @@
+package com.food.common.integration.user;
+
+import com.food.common.integration.SuperIntegrationTest;
+import com.food.common.user.domain.SocialAccount;
+import com.food.common.user.domain.User;
+import com.food.common.user.repository.SocialAccountRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.validation.ConstraintViolationException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class SocialAccountRepositoryTests extends SuperIntegrationTest {
+
+    @Autowired
+    private SocialAccountRepository socialAccountRepository;
+
+    private User mockUser;
+
+    @BeforeEach
+    void setup() {
+        mockUser = userFactory.user();
+    }
+
+    @DisplayName("SocialAccount가 정상적으로 저장된다")
+    @Test
+    void shouldSaveAppAccount() {
+        SocialAccount account = SocialAccount.create("testUser@email.com", mockUser);
+
+        SocialAccount savedAccount = socialAccountRepository.save(account);
+        assertThat(savedAccount).isNotNull();
+        assertThat(savedAccount.getId()).isNotNull();
+    }
+
+    @DisplayName("SocialAccount 유효성 실패케이이스를 검증한다")
+    @Test
+    void shouldBeFailedValidation() {
+        assertAll(
+                () -> assertAll(Stream.of(null, "", " ", "   ")
+                        .map(wrongLoginId -> (Executable) () -> {
+                            SocialAccount account = SocialAccount.create(wrongLoginId, mockUser);
+
+                            assertThatThrownBy(() -> socialAccountRepository.save(account),
+                                    "SocialAccount의 LoginId가 공백일 경우 유효성 검증에 실패해야한다. value="+wrongLoginId)
+                                    .isInstanceOf(ConstraintViolationException.class);
+                        }).collect(Collectors.toList())),
+
+                () -> {
+                    SocialAccount account = SocialAccount.create("testUser@email.com", null);
+
+                    assertThatThrownBy(() -> socialAccountRepository.save(account),
+                            "SocialAccount의 User가 null일 경우 유효성 검증에 실패해야한다")
+                            .isInstanceOf(ConstraintViolationException.class);
+                }
+        );
+    }
+}

--- a/common/src/test/java/com/food/common/integration/user/StoreOwnerRepositoryTests.java
+++ b/common/src/test/java/com/food/common/integration/user/StoreOwnerRepositoryTests.java
@@ -1,0 +1,41 @@
+package com.food.common.integration.user;
+
+import com.food.common.integration.SuperIntegrationTest;
+import com.food.common.user.domain.StoreOwner;
+import com.food.common.user.domain.User;
+import com.food.common.user.repository.StoreOwnerRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.validation.ConstraintViolationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class StoreOwnerRepositoryTests extends SuperIntegrationTest {
+
+    @Autowired
+    private StoreOwnerRepository storeOwnerRepository;
+
+    @DisplayName("StoreOwner가 정상적으로 저장된다")
+    @Test
+    void shouldSaveStoreOwner() {
+        User mockUser = userFactory.user();
+        StoreOwner storeOwner = StoreOwner.create(mockUser);
+
+        StoreOwner savedStoreOwner = storeOwnerRepository.save(storeOwner);
+        assertThat(savedStoreOwner).isNotNull();
+        assertThat(savedStoreOwner.getId()).isNotNull();
+    }
+
+    @DisplayName("SocialAccount 유효성 실패케이이스를 검증한다")
+    @Test
+    void shouldBeFailedValidation_whenSaveStoreOwnerWithNullUser() {
+        User mockUser = null;
+        StoreOwner storeOwner = StoreOwner.create(mockUser);
+
+        assertThatThrownBy(() -> storeOwnerRepository.save(storeOwner))
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+}

--- a/common/src/test/java/com/food/common/integration/user/UserRepositoryTests.java
+++ b/common/src/test/java/com/food/common/integration/user/UserRepositoryTests.java
@@ -1,6 +1,6 @@
 package com.food.common.integration.user;
 
-import com.food.common.integration.SuperIntegrationTest;
+import com.food.common.mock.MockUser;
 import com.food.common.user.domain.User;
 import com.food.common.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -14,15 +14,18 @@ import javax.validation.ConstraintViolationException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class RepositoryTests extends SuperIntegrationTest {
+public class UserRepositoryTests {
+
     @Autowired
     private UserRepository userRepository;
 
     @DisplayName("User가 정상적으로 저장된다")
     @Test
     void shouldSaveUser() {
-        User userA = User.create("userA");
-        User savedUser = userRepository.save(userA);
+        User user = MockUser.builder()
+                .nickname("userA")
+                .build();
+        User savedUser = userRepository.save(user);
 
         assertThat(savedUser).isNotNull();
         assertThat(savedUser.getId()).isNotNull();
@@ -32,9 +35,11 @@ public class RepositoryTests extends SuperIntegrationTest {
     @ParameterizedTest
     @ValueSource(strings = {"", " ", "   "})
     void shouldThrowException_whenSaveUserWithBlankNickname(String nickname) {
-        User userA = User.create(nickname);
+        User user = MockUser.builder()
+                .nickname(nickname)
+                .build();
 
-        assertThatThrownBy(() -> userRepository.save(userA))
+        assertThatThrownBy(() -> userRepository.save(user))
                 .isInstanceOf(ConstraintViolationException.class);
     }
 }

--- a/common/src/test/java/com/food/common/integration/user/UserRepositoryTests.java
+++ b/common/src/test/java/com/food/common/integration/user/UserRepositoryTests.java
@@ -1,5 +1,6 @@
 package com.food.common.integration.user;
 
+import com.food.common.integration.SuperIntegrationTest;
 import com.food.common.mock.MockUser;
 import com.food.common.user.domain.User;
 import com.food.common.user.repository.UserRepository;
@@ -14,8 +15,7 @@ import javax.validation.ConstraintViolationException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class UserRepositoryTests {
-
+public class UserRepositoryTests extends SuperIntegrationTest {
     @Autowired
     private UserRepository userRepository;
 

--- a/common/src/test/java/com/food/common/mock/MockAddress.java
+++ b/common/src/test/java/com/food/common/mock/MockAddress.java
@@ -1,0 +1,66 @@
+package com.food.common.mock;
+
+import com.food.common.address.domain.Address;
+
+public class MockAddress {
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Long id;
+        private String postCode = "06628";
+        private String sido = "서울특별시";
+        private String sigungu = "서초시";
+        private Address.Type type = Address.Type.ROAD;
+        private String typeAddress = "강남대로";
+        private Short mainNo = 311;
+        private Short subNo = 0;
+        private String referenceAddress = "(서초동)";
+
+        public Builder postCode(String postCode) {
+            this.postCode = postCode;
+            return this;
+        }
+
+        public Builder sido(String sido) {
+            this.sido = sido;
+            return this;
+        }
+
+        public Builder sigungu(String sigungu) {
+            this.sigungu = sigungu;
+            return this;
+        }
+
+        public Builder type(Address.Type type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder typeAddress(String typeAddress) {
+            this.typeAddress = typeAddress;
+            return this;
+        }
+
+        public Builder mainNo(Short mainNo) {
+            this.mainNo = mainNo;
+            return this;
+        }
+
+        public Builder subNo(Short subNo) {
+            this.subNo = subNo;
+            return this;
+        }
+
+        public Builder referenceAddress(String referenceAddress) {
+            this.referenceAddress = referenceAddress;
+            return this;
+        }
+
+        public Address build() {
+            return Address.create(
+                    postCode, sido, sigungu, type, typeAddress, mainNo, subNo, referenceAddress);
+        }
+    }
+}

--- a/common/src/test/java/com/food/common/mock/MockUser.java
+++ b/common/src/test/java/com/food/common/mock/MockUser.java
@@ -1,0 +1,28 @@
+package com.food.common.mock;
+
+import com.food.common.user.domain.User;
+
+public class MockUser {
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Long id;
+        private String nickname = "TestUser";
+
+        public Builder id(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder nickname(String nickname) {
+            this.nickname = nickname;
+            return this;
+        }
+
+        public User build() {
+            return User.create(nickname);
+        }
+    }
+}

--- a/common/src/test/resources/schema.sql
+++ b/common/src/test/resources/schema.sql
@@ -1,0 +1,4 @@
+create table tb_user (
+    user_id bigint auto_increment primary key,
+    nickname varchar(30) not null
+);

--- a/common/src/test/resources/schema.sql
+++ b/common/src/test/resources/schema.sql
@@ -1,9 +1,11 @@
-create table tb_user (
+create table tb_user
+(
     user_id bigint auto_increment primary key,
     nickname varchar(30) not null
 );
 
-create table tb_app_account (
+create table tb_app_account
+(
     app_account_id bigint auto_increment primary key,
     login_id varchar(50) not null unique,
     password varchar(100) not null,
@@ -11,9 +13,165 @@ create table tb_app_account (
     created_date datetime not null default now()
 );
 
-create table tb_social_account (
+create table tb_social_account
+(
     app_account_id bigint auto_increment primary key,
     login_id varchar(50) not null unique,
     user_id bigint not null unique,
     created_date datetime not null default now()
+);
+
+create table tb_store_owner
+(
+    store_owner_id bigint auto_increment primary key,
+    user_id bigint not null unique,
+    created_date datetime not null default now()
+);
+
+create table tb_address
+(
+    address_id bigint auto_increment primary key,
+    post_code varchar(30) not null,
+    sido varchar(30) not null,
+    sigungu varchar(30) not null,
+    type enum('ROAD', 'JIBUN') not null,
+    type_address varchar(100) not null,
+    main_no smallint not null,
+    sub_no smallint not null,
+    reference_address varchar(30)
+);
+
+create table tb_store
+(
+    store_id bigint auto_increment primary key,
+    name varchar(50) not null,
+    store_owner_id bigint not null,
+    min_order_amount mediumint not null,
+    open_status enum('OPEN', 'CLOSED') not null
+);
+
+create table tb_store_operating_time
+(
+    store_operating_time_id bigint auto_increment primary key,
+    store_id bigint not null,
+    week enum('mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun' not null,
+    opening_time time not null,
+    closing_time time not null comment '영업 종료일시'
+);
+
+create table tb_store_address
+(
+    store_address_id bigint auto_increment primary key,
+    store_id         bigint not null,
+    address_id       bigint not null,
+    address_detail   varchar(150)
+);
+
+create table tb_menu
+(
+    menu_id bigint auto_increment primary key,
+    store_id bigint not null,
+    name varchar(50) not null,
+    amount mediumint not null default 0,
+    cooking_time time not null
+);
+
+create table tb_food_category
+(
+    food_category_id bigint auto_increment primary key,
+    name varchar(15) not null unique
+);
+
+create table tb_store_food_category
+(
+    store_id bigint primary key,
+    food_category_id bigint primary key
+);
+
+create table tb_image
+(
+    image_id bigint auto_increment primary key,
+    path varchar(200) not null,
+    name varchar(50) not null,
+    created_date datetime not null default now()
+);
+
+create table tb_store_image
+(
+    store_id bigint primary key,
+    image_id bigint primary key
+);
+
+create table tb_order
+(
+    order_id bigint auto_increment primary key,
+    user_id bigint not null,
+    store_id bigint not null,
+    created_date datetime not null default now(),
+    amount int not null,
+    status enum('REQUEST', 'COOKING', 'COMPLETED', 'CANCELED') not null,
+    comment varchar(150)
+);
+
+create table tb_order_menu
+(
+    order_menu_id bigint auto_increment primary key,
+    order_id bigint not null,
+    menu_id bigint not null,
+    amount int not null default 0,
+    count tinyint not null default 0
+)
+
+create table tb_order_menu_selection
+(
+    order_menu_selection_id bigint auto_increment primary key,
+    order_menu_id int not null,
+    menu_selection_id bigint not null
+)
+
+create table tb_payment
+(
+    payment_id bigint auto_increment primary key,
+    order_id bigint not null,
+    status enum('PAYMENT_REQUEST', 'PAYMENT_COMPLETED',
+        'CANCELLATION_REQUEST', 'CANCELLATION_COMPLETED') not null,
+    created_date datetime not null default now()
+);
+
+create table tb_payment_log
+(
+    payment_log_id bigint auto_increment primary key,
+    payment_id bigint not null,
+    method enum('CARD', 'ACCOUNT_TRANSFER', 'POINT' ) not null,
+    amount mediumint not null default 0,
+    type enum('PAYMENT', 'CANCELLATION' ) not null default 0,
+    point_id mediumint null default 0
+);
+
+create table tb_point
+(
+    point_id bigint auto_increment primary key,
+    user_id bigint not null,
+    type enum('USE', 'COLLECT') not null,
+    changed_amount mediumint not null default 0,
+    current_amount mediumint not null default 0,
+    payment_id bigint,
+    created_date datetime not null default now()
+);
+
+create table tb_review
+(
+    review_id bigint auto_increment primary key,
+    user_id bigint not null,
+    store_id bigint not null,
+    order_id bigint not null,
+    score tinyint not null,
+    content varchar(1000) not null,
+    created_date datetime not null default now()
+);
+
+create table tb_review_image
+(
+    review_id bigint primary key,
+    image_id bigint primary key
 );

--- a/common/src/test/resources/schema.sql
+++ b/common/src/test/resources/schema.sql
@@ -10,3 +10,10 @@ create table tb_app_account (
     user_id bigint not null unique,
     created_date datetime not null default now()
 );
+
+create table tb_social_account (
+    app_account_id bigint auto_increment primary key,
+    login_id varchar(50) not null unique,
+    user_id bigint not null unique,
+    created_date datetime not null default now()
+);

--- a/common/src/test/resources/schema.sql
+++ b/common/src/test/resources/schema.sql
@@ -2,3 +2,11 @@ create table tb_user (
     user_id bigint auto_increment primary key,
     nickname varchar(30) not null
 );
+
+create table tb_app_account (
+    app_account_id bigint auto_increment primary key,
+    login_id varchar(50) not null unique,
+    password varchar(100) not null,
+    user_id bigint not null unique,
+    created_date datetime not null default now()
+);

--- a/common/src/test/resources/schema.sql
+++ b/common/src/test/resources/schema.sql
@@ -34,7 +34,7 @@ create table tb_address
     post_code varchar(30) not null,
     sido varchar(30) not null,
     sigungu varchar(30) not null,
-    type enum('ROAD', 'JIBUN') not null,
+    type varchar(10) not null,
     type_address varchar(100) not null,
     main_no smallint not null,
     sub_no smallint not null,
@@ -54,7 +54,7 @@ create table tb_store_operating_time
 (
     store_operating_time_id bigint auto_increment primary key,
     store_id bigint not null,
-    week enum('mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun' not null,
+    week enum('MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN') not null,
     opening_time time not null,
     closing_time time not null comment '영업 종료일시'
 );
@@ -84,9 +84,11 @@ create table tb_food_category
 
 create table tb_store_food_category
 (
-    store_id bigint primary key,
-    food_category_id bigint primary key
+    store_id bigint not null,
+    food_category_id bigint not null
 );
+
+ALTER TABLE tb_store_food_category ADD PRIMARY KEY (store_id, food_category_id);
 
 create table tb_image
 (
@@ -98,9 +100,11 @@ create table tb_image
 
 create table tb_store_image
 (
-    store_id bigint primary key,
-    image_id bigint primary key
+    store_id bigint not null,
+    image_id bigint not null
 );
+
+ALTER TABLE tb_store_image ADD PRIMARY KEY (store_id, image_id);
 
 create table tb_order
 (
@@ -120,14 +124,14 @@ create table tb_order_menu
     menu_id bigint not null,
     amount int not null default 0,
     count tinyint not null default 0
-)
+);
 
 create table tb_order_menu_selection
 (
     order_menu_selection_id bigint auto_increment primary key,
     order_menu_id int not null,
     menu_selection_id bigint not null
-)
+);
 
 create table tb_payment
 (
@@ -172,6 +176,8 @@ create table tb_review
 
 create table tb_review_image
 (
-    review_id bigint primary key,
-    image_id bigint primary key
+    review_id bigint not null,
+    image_id bigint not null
 );
+
+ALTER TABLE tb_review_image ADD PRIMARY KEY (review_id, image_id);

--- a/common/src/test/resources/schema.sql
+++ b/common/src/test/resources/schema.sql
@@ -73,7 +73,7 @@ create table tb_menu
     store_id bigint not null,
     name varchar(50) not null,
     amount mediumint not null default 0,
-    cooking_time time not null
+    cooking_time mediumint not null
 );
 
 create table tb_food_category

--- a/common/src/test/resources/schema.sql
+++ b/common/src/test/resources/schema.sql
@@ -109,7 +109,7 @@ ALTER TABLE tb_store_image ADD PRIMARY KEY (store_id, image_id);
 create table tb_order
 (
     order_id bigint auto_increment primary key,
-    user_id bigint not null,
+    customer_id bigint not null,
     store_id bigint not null,
     created_date datetime not null default now(),
     amount int not null,
@@ -166,7 +166,7 @@ create table tb_point
 create table tb_review
 (
     review_id bigint auto_increment primary key,
-    user_id bigint not null,
+    writer_id bigint not null,
     store_id bigint not null,
     order_id bigint not null,
     score tinyint not null,


### PR DESCRIPTION
작업 내용 : #4 

## Entity 생성
저번 PR 때의 백엔드에서 생성되는 데이터를 고려하여 `Validation`은 `Field`에 추가하였습니다.   
유효성 검증에 대한 테스트케이스는 아직 다 구현하지 못한 상태입니다..! ㅠㅠ   
현재는 통합테스트로 유효성 검증을 하고 있지만 다음 PR때 단위테스트로 변경할 예정입니다.  

## MariaDB 연동
* AWS RDS의 주소로 연동하였습니다! 비밀 파일 관리(db, auth 설정파일 등) 구현은 추후에 하겠습니다~!