### PR TITLE
restdocs index 페이지 생성 및 common 스니펫 테스트 케이스 작성

### DIFF
--- a/src/docs/asciidocs/content/1_common.adoc
+++ b/src/docs/asciidocs/content/1_common.adoc
@@ -1,0 +1,47 @@
+== 1. 공통 (Common)
+
+[%hardbreaks]
+<<Http-Message-Description>>
+<<Common-Response-Form>>
+
+[#Http-Message-Description]
+=== 1-1. HTTP 메시지 설명 Title
+|===
+|Title|Description
+|`+HTTP Request+`
+|HTTP 요청 메시지 예시
+
+|`+Request Header+`
+|Http 요청메시지 Header
+
+|`+Path Parameter+`
+|URI에 포함되는 데이터 +
+ex) /api/posts/`1`
+
+|`+Request Parameter+`
+|URI 뒤에 쿼리 스트링 데이터 +
+ex) /api/posts?`search=abc`
+
+|`+Request Parts+`
+|multipart로 전송시 file/text 데이터
+
+|`+Request Fields+`
+|Request Body
+
+|`+HTTP Response+`
+|HTTP 응답 메시지 예시
+
+|`+Response Fields+`
+|Response Body
+
+|`+Response fields-content+`
+|Response body의 content에 포함되어 있는 데이터들
+|===
+
+
+[#Common-Response-Form]
+=== 1-2. 공통 응답 형식
+==== 성공 케이스
+operation::common/result/success[snippets='response-fields']
+==== 실패 케이스
+operation::common/result/failure[snippets='response-fields']

--- a/src/docs/asciidocs/index.adoc
+++ b/src/docs/asciidocs/index.adoc
@@ -1,0 +1,10 @@
+= Api Document
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 1
+:sectlinks:
+:docinfo: shared-head
+
+include::/{docfile}/../content/1_common.adoc[]

--- a/src/test/java/com/food/api/RestDocsIndexController.java
+++ b/src/test/java/com/food/api/RestDocsIndexController.java
@@ -1,0 +1,30 @@
+package com.food.api;
+
+import com.food.common.annotation.ApiFor;
+import com.food.common.apiResult.FailResult;
+import com.food.common.apiResult.SuccessResult;
+import com.food.common.user.enumeration.Role;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@ApiFor(roles = Role.ALL)
+@RestController
+public class RestDocsIndexController {
+
+    /**************************************************************************************************************
+     * 성공 결과 케이스 가져오기
+     *************************************************************************************************************/
+    @GetMapping("/api/result/success")
+    public ResponseEntity<SuccessResult<Object>> getSuccessResult() {
+        return ResponseEntity.ok(SuccessResult.createResult(new Object()));
+    }
+
+    /**************************************************************************************************************
+     * 실패 결과 케이스 가져오기
+     *************************************************************************************************************/
+    @GetMapping("/api/result/failure")
+    public ResponseEntity<FailResult> getFailResult() {
+        return ResponseEntity.ok(FailResult.createResult("test-12345", "failure message"));
+    }
+}

--- a/src/test/java/com/food/api/RestDocsIndexTest.java
+++ b/src/test/java/com/food/api/RestDocsIndexTest.java
@@ -1,0 +1,58 @@
+package com.food.api;
+
+import com.food.SuperIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.http.HttpHeaders.ACCEPT;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class RestDocsIndexTest extends SuperIntegrationTest {
+    private static final String DIRECT = "common/";
+
+    @Test
+    @DisplayName("요청이 성공했을 때의 형식을 가져온다")
+    void resultSuccess() throws Exception {
+        mvc.perform(get("/api/result/success")
+                        .header(ACCEPT, APPLICATION_JSON_VALUE))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("success").value(true))
+                .andDo(document(DIRECT+"result/success",
+                        responseFields(
+                                fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                fieldWithPath("content").type(OBJECT).description("요청 결과 Object").optional()
+                        )
+                ))
+        ;
+    }
+
+    @Test
+    @DisplayName("요청이 실패했을 때의 형식을 가져온다")
+    void resultFailure() throws Exception {
+        mvc.perform(get("/api/result/failure")
+                        .header(ACCEPT, APPLICATION_JSON_VALUE))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("success").value(false))
+                .andExpect(jsonPath("code").exists())
+                .andExpect(jsonPath("message").exists())
+                .andDo(document(DIRECT+"result/failure",
+                        responseFields(
+                                fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                fieldWithPath("code").type(STRING).description("실패 코드"),
+                                fieldWithPath("message").type(STRING).description("실패 메시지"),
+                                fieldWithPath("content").type(OBJECT).description("요청 결과 Object").optional()
+                        )
+                ))
+        ;
+    }
+}


### PR DESCRIPTION
API를 만들때마다 테스트케이스를 작성하면서 API 문서도 같이 작성해가면 좋을 것 같아   
`Index 페이지`와 `공통 응답 형식` 먼저 생성&작성하였습니다. 🙂